### PR TITLE
Implement serializer and deserializer for map, list and value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,10 +115,12 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 name = "cellang"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "miette",
  "regex",
  "serde",
  "serde_json",
+ "thiserror 2.0.9",
  "time",
 ]
 
@@ -262,7 +270,7 @@ dependencies = [
  "supports-unicode",
  "terminal_size",
  "textwrap",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-width",
 ]
 
@@ -481,7 +489,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+dependencies = [
+ "thiserror-impl 2.0.9",
 ]
 
 [[package]]
@@ -489,6 +506,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -13,9 +13,11 @@ categories = ["development-tools", "programming-language"]
 [dependencies]
 serde = { version = "^1", features = ["derive"] }
 miette = { version="^7"}
-serde_json = "^1"
 regex = "^1"
 time = { version="^0.3", features=["serde", "formatting", "parsing"]}
+base64 = "^0.22"
+thiserror = "^2"
 
 [dev-dependencies]
 miette = { version="^7", features = ["fancy"] }
+serde_json = "^1"

--- a/crates/lib/examples/user_role.rs
+++ b/crates/lib/examples/user_role.rs
@@ -1,4 +1,4 @@
-use cellang::{Environment, EnvironmentBuilder, Map, TokenTree, Value};
+use cellang::{Environment, EnvironmentBuilder, TokenTree, Value};
 use miette::Error;
 use serde::{Deserialize, Serialize};
 

--- a/crates/lib/examples/user_role.rs
+++ b/crates/lib/examples/user_role.rs
@@ -45,18 +45,6 @@ pub struct User {
     pub roles: Vec<String>,
 }
 
-impl From<Map> for User {
-    fn from(map: Map) -> Self {
-        User {
-            name: map.get(&"name".into()).unwrap().unwrap().to_string(),
-            roles: match map.get(&"roles".into()).unwrap().unwrap() {
-                Value::List(l) => l.iter().map(|v| v.to_string()).collect(),
-                _ => panic!("Expected a list"),
-            },
-        }
-    }
-}
-
 fn list_users() -> Result<Vec<User>, Error> {
     Ok(vec![
         User {
@@ -84,7 +72,7 @@ fn has_role(env: &Environment, tokens: &[TokenTree]) -> Result<Value, Error> {
     }
 
     let user: User = match cellang::eval_ast(env, &tokens[0])?.to_value()? {
-        Value::Map(m) => m.into(),
+        Value::Map(m) => cellang::try_from_map(m)?,
         _ => miette::bail!("Expected a map, got something else"),
     };
 

--- a/crates/lib/examples/user_role.rs
+++ b/crates/lib/examples/user_role.rs
@@ -45,19 +45,6 @@ pub struct User {
     pub roles: Vec<String>,
 }
 
-impl From<User> for Value {
-    fn from(user: User) -> Self {
-        Value::Map(
-            vec![
-                ("name".into(), user.name.into()),
-                ("roles".into(), user.roles.into()),
-            ]
-            .into_iter()
-            .collect(),
-        )
-    }
-}
-
 impl From<Map> for User {
     fn from(map: Map) -> Self {
         User {

--- a/crates/lib/src/types/de.rs
+++ b/crates/lib/src/types/de.rs
@@ -10,7 +10,6 @@ use super::{Key, List, Map};
 
 #[derive(Debug, Error, PartialEq)]
 pub enum DeserializeError {
-    // todo: improve this
     #[error("deserialization error")]
     DeserializationError(String),
 }
@@ -63,7 +62,7 @@ struct MapDeserializer<'a> {
     lifetime: std::marker::PhantomData<&'a ()>,
 }
 
-impl<'a> MapDeserializer<'a> {
+impl MapDeserializer<'_> {
     fn new(map: Map) -> Self {
         MapDeserializer {
             keys: map.clone().into_keys(),
@@ -510,31 +509,32 @@ impl<'de> serde::de::Deserializer<'de> for Value {
         self,
         _name: &'static str,
         _variants: &'static [&'static str],
-        _visitor: V,
+        visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        todo!()
+        self.deserialize_any(visitor)
     }
 
     fn deserialize_identifier<V>(
         self,
-        _visitor: V,
+        visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        todo!()
+        self.deserialize_string(visitor)
     }
 
     fn deserialize_ignored_any<V>(
         self,
-        _visitor: V,
+        visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        todo!()
+        drop(self);
+        visitor.visit_unit()
     }
 }

--- a/crates/lib/src/types/de.rs
+++ b/crates/lib/src/types/de.rs
@@ -1,0 +1,471 @@
+use crate::Value;
+use serde::{
+    de::{DeserializeSeed, SeqAccess},
+    forward_to_deserialize_any,
+};
+use std::collections::hash_map::{IntoKeys, IntoValues};
+use thiserror::Error;
+
+use super::{Key, Map};
+
+#[derive(Debug, Error, PartialEq)]
+pub enum DeserializeError {
+    // todo: improve this
+    #[error("deserialization error")]
+    DeserializationError,
+}
+
+impl serde::de::Error for DeserializeError {
+    fn custom<T: std::fmt::Display>(msg: T) -> Self {
+        DeserializeError::DeserializationError
+    }
+}
+
+struct SeqDeserializer {
+    iter: std::vec::IntoIter<Value>,
+}
+
+impl SeqDeserializer {
+    fn new(vec: Vec<Value>) -> Self {
+        SeqDeserializer {
+            iter: vec.into_iter(),
+        }
+    }
+}
+
+impl<'de> SeqAccess<'de> for SeqDeserializer {
+    type Error = DeserializeError;
+
+    fn next_element_seed<T>(
+        &mut self,
+        seed: T,
+    ) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some(value) => seed.deserialize(value).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        match self.iter.size_hint() {
+            (lower, Some(upper)) if lower == upper => Some(upper),
+            _ => None,
+        }
+    }
+}
+
+struct MapDeserializer<'a> {
+    keys: IntoKeys<Key, Value>,
+    values: IntoValues<Key, Value>,
+    lifetime: std::marker::PhantomData<&'a ()>,
+}
+
+impl<'a> MapDeserializer<'a> {
+    fn new(map: Map) -> Self {
+        MapDeserializer {
+            keys: map.clone().into_keys(),
+            values: map.into_values(),
+            lifetime: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<'de> serde::de::MapAccess<'de> for MapDeserializer<'_> {
+    type Error = DeserializeError;
+
+    fn next_key_seed<K>(
+        &mut self,
+        seed: K,
+    ) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: serde::de::DeserializeSeed<'de>,
+    {
+        match self.keys.next() {
+            Some(key) => seed.deserialize(key).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::DeserializeSeed<'de>,
+    {
+        seed.deserialize(self.values.next().unwrap())
+    }
+}
+
+impl<'de> serde::de::Deserializer<'de> for Key {
+    type Error = DeserializeError;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self {
+            Key::String(s) => visitor.visit_string(s),
+            Key::Int(i) => visitor.visit_i64(i),
+            Key::Uint(i) => visitor.visit_u64(i),
+            Key::Bool(b) => visitor.visit_bool(b),
+        }
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string bytes byte_buf option map unit unit_struct newtype_struct seq tuple tuple_struct struct enum identifier ignored_any
+    }
+}
+
+impl<'de> serde::de::Deserializer<'de> for Map {
+    type Error = DeserializeError;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_map(MapDeserializer::new(self))
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string bytes byte_buf option unit map unit_struct newtype_struct seq tuple tuple_struct struct enum identifier ignored_any
+    }
+}
+
+impl<'de> serde::de::Deserializer<'de> for Value {
+    type Error = DeserializeError;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        let m = match self {
+            Value::Map(m) => m,
+            _ => return Err(DeserializeError::DeserializationError),
+        };
+
+        visitor.visit_map(MapDeserializer::new(m))
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self {
+            Value::Bool(b) => visitor.visit_bool(b),
+            _ => Err(DeserializeError::DeserializationError),
+        }
+    }
+
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self {
+            Value::Int(i) => visitor.visit_i8(i as i8),
+            _ => Err(DeserializeError::DeserializationError),
+        }
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self {
+            Value::Int(i) => visitor.visit_i16(i as i16),
+            _ => Err(DeserializeError::DeserializationError),
+        }
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self {
+            Value::Int(i) => visitor.visit_i32(i as i32),
+            _ => Err(DeserializeError::DeserializationError),
+        }
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self {
+            Value::Int(i) => visitor.visit_i64(i),
+            _ => Err(DeserializeError::DeserializationError),
+        }
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self {
+            Value::Uint(i) => visitor.visit_u8(i as u8),
+            _ => Err(DeserializeError::DeserializationError),
+        }
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self {
+            Value::Uint(i) => visitor.visit_u16(i as u16),
+            _ => Err(DeserializeError::DeserializationError),
+        }
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self {
+            Value::Uint(i) => visitor.visit_u32(i as u32),
+            _ => Err(DeserializeError::DeserializationError),
+        }
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self {
+            Value::Uint(i) => visitor.visit_u64(i),
+            _ => Err(DeserializeError::DeserializationError),
+        }
+    }
+
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self {
+            Value::Double(f) => visitor.visit_f32(f as f32),
+            _ => Err(DeserializeError::DeserializationError),
+        }
+    }
+
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self {
+            Value::Double(f) => visitor.visit_f64(f),
+            _ => Err(DeserializeError::DeserializationError),
+        }
+    }
+
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self {
+            Value::String(s) => {
+                if s.len() == 1 {
+                    visitor.visit_char(s.chars().next().unwrap())
+                } else {
+                    Err(DeserializeError::DeserializationError)
+                }
+            }
+            _ => Err(DeserializeError::DeserializationError),
+        }
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self {
+            Value::String(s) => visitor.visit_str(&s),
+            _ => Err(DeserializeError::DeserializationError),
+        }
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self {
+            Value::String(s) => visitor.visit_string(s),
+            _ => Err(DeserializeError::DeserializationError),
+        }
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self {
+            Value::Bytes(b) => visitor.visit_bytes(&b),
+            _ => Err(DeserializeError::DeserializationError),
+        }
+    }
+
+    fn deserialize_byte_buf<V>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self {
+            Value::Bytes(b) => visitor.visit_byte_buf(b),
+            _ => Err(DeserializeError::DeserializationError),
+        }
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self {
+            Value::Null => visitor.visit_none(),
+            _ => visitor.visit_some(self),
+        }
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self {
+            Value::Null => visitor.visit_unit(),
+            _ => Err(DeserializeError::DeserializationError),
+        }
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self {
+            Value::Null => visitor.visit_unit(),
+            _ => Err(DeserializeError::DeserializationError),
+        }
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        let vec = match self {
+            Value::List(l) => l.inner().clone(),
+            _ => return Err(DeserializeError::DeserializationError),
+        };
+
+        let seq = SeqDeserializer::new(vec);
+        visitor.visit_seq(seq)
+    }
+
+    fn deserialize_tuple<V>(
+        self,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        let vals = match self {
+            Value::Map(m) => {
+                let mut v = m
+                    .into_iter()
+                    .map(|(k, v)| match k {
+                        Key::Int(i) => (i, v),
+                        _ => panic!("unexpected key type"),
+                    })
+                    .collect::<Vec<(i64, Value)>>();
+                v.sort_by_key(|(k, _)| *k);
+                v.into_iter().map(|(_, v)| v).collect()
+            }
+            _ => return Err(DeserializeError::DeserializationError),
+        };
+
+        let seq = SeqDeserializer::new(vals);
+        visitor.visit_seq(seq)
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        self.deserialize_tuple(len, visitor)
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        let m = match self {
+            Value::Map(m) => m,
+            _ => return Err(DeserializeError::DeserializationError),
+        };
+
+        visitor.visit_map(MapDeserializer::new(m))
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        self.deserialize_any(visitor)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        todo!()
+    }
+
+    fn deserialize_identifier<V>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        todo!()
+    }
+
+    fn deserialize_ignored_any<V>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        todo!()
+    }
+}

--- a/crates/lib/src/types/list.rs
+++ b/crates/lib/src/types/list.rs
@@ -19,6 +19,10 @@ impl List {
         }
     }
 
+    pub fn inner(&self) -> &Vec<Value> {
+        &self.inner
+    }
+
     pub fn element_type(&self) -> Option<ValueKind> {
         self.elem_type.clone()
     }
@@ -275,6 +279,28 @@ impl List {
             }
         }
         Ok(())
+    }
+}
+
+impl Extend<Value> for List {
+    fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = Value>,
+    {
+        for value in iter {
+            self.push(value).unwrap();
+        }
+    }
+}
+
+impl FromIterator<Value> for List {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = Value>,
+    {
+        let mut list = List::new();
+        list.extend(iter);
+        list
     }
 }
 

--- a/crates/lib/src/types/list.rs
+++ b/crates/lib/src/types/list.rs
@@ -11,22 +11,6 @@ pub struct List {
     inner: Vec<Value>,
 }
 
-impl<T> From<Vec<T>> for List
-where
-    T: Into<Value>,
-{
-    fn from(values: Vec<T>) -> Self {
-        if values.is_empty() {
-            Self::new()
-        } else {
-            let mut list = List::with_capacity(values.len());
-            list.inner = values.into_iter().map(Into::into).collect();
-            list.elem_type = list.inner.first().map(Value::kind);
-            list
-        }
-    }
-}
-
 impl List {
     pub fn new() -> Self {
         Self {
@@ -294,6 +278,22 @@ impl List {
     }
 }
 
+impl<T> From<Vec<T>> for List
+where
+    T: Into<Value>,
+{
+    fn from(values: Vec<T>) -> Self {
+        if values.is_empty() {
+            Self::new()
+        } else {
+            let mut list = List::with_capacity(values.len());
+            list.inner = values.into_iter().map(Into::into).collect();
+            list.elem_type = list.inner.first().map(Value::kind);
+            list
+        }
+    }
+}
+
 impl IntoIterator for List {
     type Item = Value;
     type IntoIter = vec::IntoIter<Value>;
@@ -323,7 +323,7 @@ impl<'de> Deserialize<'de> for List {
     where
         D: Deserializer<'de>,
     {
-        let inner: Vec<serde_json::Value> = Vec::deserialize(deserializer)?;
+        let inner: Vec<Value> = Vec::deserialize(deserializer)?;
         Ok(List::from(inner))
     }
 }

--- a/crates/lib/src/types/mod.rs
+++ b/crates/lib/src/types/mod.rs
@@ -17,6 +17,7 @@ use crate::Environment;
 pub type Function =
     Box<dyn Fn(&Environment, &[TokenTree]) -> Result<Value, Error>>;
 
+/// Function is a wrapper for turning Value into any type that implements DeserializeOwned.
 pub fn try_from_value<T>(value: Value) -> Result<T, Error>
 where
     T: serde::de::DeserializeOwned,
@@ -27,6 +28,7 @@ where
     }
 }
 
+/// Function is a wrapper for turning Map into any type that implements DeserializeOwned.
 pub fn try_from_map<T>(value: Map) -> Result<T, Error>
 where
     T: serde::de::DeserializeOwned,
@@ -37,6 +39,7 @@ where
     }
 }
 
+/// Function is a wrapper for turning List into any type that implements DeserializeOwned.
 pub fn try_from_list<T>(value: List) -> Result<T, Error>
 where
     T: serde::de::DeserializeOwned,

--- a/crates/lib/src/types/mod.rs
+++ b/crates/lib/src/types/mod.rs
@@ -1,3 +1,4 @@
+mod de;
 pub mod list;
 pub mod map;
 mod ser;
@@ -15,3 +16,23 @@ use crate::Environment;
 /// Function is a wrapper for a dynamic function that can be registered in the environment.
 pub type Function =
     Box<dyn Fn(&Environment, &[TokenTree]) -> Result<Value, Error>>;
+
+pub fn try_from_value<T>(value: Value) -> Result<T, Error>
+where
+    T: serde::de::DeserializeOwned,
+{
+    match T::deserialize(value) {
+        Ok(value) => Ok(value),
+        Err(err) => miette::bail!("Failed to deserialize value: {}", err),
+    }
+}
+
+pub fn try_from_map<T>(value: Map) -> Result<T, Error>
+where
+    T: serde::de::DeserializeOwned,
+{
+    match T::deserialize(value) {
+        Ok(value) => Ok(value),
+        Err(err) => miette::bail!("Failed to deserialize value: {}", err),
+    }
+}

--- a/crates/lib/src/types/mod.rs
+++ b/crates/lib/src/types/mod.rs
@@ -36,3 +36,13 @@ where
         Err(err) => miette::bail!("Failed to deserialize value: {}", err),
     }
 }
+
+pub fn try_from_list<T>(value: List) -> Result<T, Error>
+where
+    T: serde::de::DeserializeOwned,
+{
+    match T::deserialize(value) {
+        Ok(value) => Ok(value),
+        Err(err) => miette::bail!("Failed to deserialize value: {}", err),
+    }
+}

--- a/crates/lib/src/types/mod.rs
+++ b/crates/lib/src/types/mod.rs
@@ -1,5 +1,6 @@
 pub mod list;
 pub mod map;
+mod ser;
 pub mod value;
 
 pub use self::list::*;

--- a/crates/lib/src/types/ser.rs
+++ b/crates/lib/src/types/ser.rs
@@ -1,0 +1,427 @@
+use super::{Key, List, Map, Value};
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum SerializeError {
+    #[error("Invalid key {0}")]
+    InvalidKey(String),
+    #[error("Serde error: {0}")]
+    SerdeError(String),
+}
+
+impl serde::ser::Error for SerializeError {
+    fn custom<T: std::fmt::Display>(msg: T) -> Self {
+        SerializeError::SerdeError(msg.to_string())
+    }
+}
+
+pub(crate) struct SerializeSeq {
+    inner: Vec<Value>,
+}
+
+impl serde::ser::SerializeSeq for SerializeSeq {
+    type Ok = Value;
+    type Error = SerializeError;
+
+    fn serialize_element<T: ?Sized + serde::Serialize>(
+        &mut self,
+        value: &T,
+    ) -> Result<(), SerializeError> {
+        self.inner.push(value.serialize(Serializer)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Value, SerializeError> {
+        Ok(Value::List(List::from(self.inner)))
+    }
+}
+
+impl serde::ser::SerializeTuple for SerializeSeq {
+    type Ok = Value;
+    type Error = SerializeError;
+
+    fn serialize_element<T: ?Sized + serde::Serialize>(
+        &mut self,
+        value: &T,
+    ) -> Result<(), SerializeError> {
+        self.inner.push(value.serialize(Serializer)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Value, SerializeError> {
+        let mut m = Map::new();
+        for (i, v) in self.inner.into_iter().enumerate() {
+            let key = Key::from(i as i64);
+            m.insert(key, v)
+                .map_err(|err| SerializeError::InvalidKey(err.to_string()))?;
+        }
+        Ok(Value::Map(m))
+    }
+}
+
+impl serde::ser::SerializeTupleStruct for SerializeSeq {
+    type Ok = Value;
+    type Error = SerializeError;
+
+    fn serialize_field<T: ?Sized + serde::Serialize>(
+        &mut self,
+        value: &T,
+    ) -> Result<(), SerializeError> {
+        self.inner.push(value.serialize(Serializer)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Value, SerializeError> {
+        let mut m = Map::new();
+        for (i, v) in self.inner.into_iter().enumerate() {
+            let key = Key::from(i as i64);
+            m.insert(key, v)
+                .map_err(|err| SerializeError::InvalidKey(err.to_string()))?;
+        }
+        Ok(Value::Map(m))
+    }
+}
+
+pub(crate) struct SerializeTupleVariant {
+    key: Key,
+    inner: Vec<Value>,
+}
+
+impl serde::ser::SerializeTupleVariant for SerializeTupleVariant {
+    type Ok = Value;
+    type Error = SerializeError;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        self.inner.push(value.serialize(Serializer)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        let mut m = Map::new();
+        for (i, v) in self.inner.into_iter().enumerate() {
+            let key = Key::from(i as i64);
+            m.insert(key, v)
+                .map_err(|err| SerializeError::InvalidKey(err.to_string()))?;
+        }
+        let value = Value::Map(m);
+        let key = self.key;
+        Ok(Value::Map(vec![(key, value)].into_iter().collect()))
+    }
+}
+
+pub(crate) struct SerializeMap {
+    keys: Vec<Key>,
+    values: Vec<Value>,
+}
+
+impl serde::ser::SerializeMap for SerializeMap {
+    type Ok = Value;
+    type Error = SerializeError;
+
+    fn serialize_key<T: ?Sized + serde::Serialize>(
+        &mut self,
+        key: &T,
+    ) -> Result<(), SerializeError> {
+        let key = key.serialize(Serializer)?;
+        match Key::try_from(&key) {
+            Ok(key) => self.keys.push(key),
+            Err(_) => return Err(SerializeError::InvalidKey(key.to_string())),
+        }
+        Ok(())
+    }
+
+    fn serialize_value<T: ?Sized + serde::Serialize>(
+        &mut self,
+        value: &T,
+    ) -> Result<(), SerializeError> {
+        self.values.push(value.serialize(Serializer)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Value, SerializeError> {
+        let mut map = Map::with_capacity(self.keys.len());
+        for (key, value) in self.keys.into_iter().zip(self.values.into_iter()) {
+            map.insert(key, value)
+                .map_err(|err| SerializeError::InvalidKey(err.to_string()))?;
+        }
+        Ok(Value::Map(map))
+    }
+}
+
+impl serde::ser::SerializeStruct for SerializeMap {
+    type Ok = Value;
+    type Error = SerializeError;
+
+    fn serialize_field<T>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        let key = Key::from(key);
+        let value = value.serialize(Serializer)?;
+        self.keys.push(key);
+        self.values.push(value);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        let mut map = Map::with_capacity(self.keys.len());
+        for (key, value) in self.keys.into_iter().zip(self.values.into_iter()) {
+            map.insert(key, value)
+                .map_err(|err| SerializeError::InvalidKey(err.to_string()))?;
+        }
+        Ok(Value::Map(map))
+    }
+}
+
+pub(crate) struct SerializeMapVariant {
+    name: Key,
+    keys: Vec<Key>,
+    values: Vec<Value>,
+}
+
+impl serde::ser::SerializeStructVariant for SerializeMapVariant {
+    type Ok = Value;
+    type Error = SerializeError;
+
+    fn serialize_field<T>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        let key = Key::from(key);
+        let value = value.serialize(Serializer)?;
+        self.keys.push(key);
+        self.values.push(value);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        let mut map = Map::with_capacity(self.keys.len());
+        for (key, value) in self.keys.into_iter().zip(self.values.into_iter()) {
+            map.insert(key, value)
+                .map_err(|err| SerializeError::InvalidKey(err.to_string()))?;
+        }
+        let key = self.name;
+        Ok(Value::Map(
+            vec![(key, Value::Map(map))].into_iter().collect(),
+        ))
+    }
+}
+
+pub(crate) struct Serializer;
+
+impl serde::ser::Serializer for Serializer {
+    type Ok = Value;
+    type Error = SerializeError;
+
+    // SerializeSeq produces a List<Value>
+    type SerializeSeq = SerializeSeq;
+    // SerializeTuple produces a Map<Key::Int, Value>
+    type SerializeTuple = SerializeSeq;
+    // SerializeTupleStruct produces a Map<Key::Int, Value>
+    type SerializeTupleStruct = SerializeSeq;
+    // SerializeTupleVariant produces a Map<Key::Int, Value>
+    type SerializeTupleVariant = SerializeTupleVariant;
+    type SerializeMap = SerializeMap;
+    type SerializeStruct = SerializeMap;
+    type SerializeStructVariant = SerializeMapVariant;
+
+    fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Bool(v))
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Int(v as i64))
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Int(v as i64))
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Int(v as i64))
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Int(v))
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Uint(v as u64))
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Uint(v as u64))
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Uint(v as u64))
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Uint(v))
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Double(v as f64))
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Double(v))
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        self.serialize_str(&v.to_string())
+    }
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::String(v.to_string()))
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Bytes(v.to_vec()))
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Null)
+    }
+
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Null)
+    }
+
+    // struct Unit => null
+    fn serialize_unit_struct(
+        self,
+        _name: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Null)
+    }
+
+    /// enum E { V } => { "V": null }
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        let key = Key::from(variant);
+        let value = Value::Null;
+        Ok(Value::Map(vec![(key, value)].into_iter().collect()))
+    }
+
+    fn serialize_newtype_struct<T>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_seq(
+        self,
+        len: Option<usize>,
+    ) -> Result<Self::SerializeSeq, Self::Error> {
+        Ok(SerializeSeq {
+            inner: Vec::with_capacity(len.unwrap_or(0)),
+        })
+    }
+
+    fn serialize_tuple(
+        self,
+        len: usize,
+    ) -> Result<Self::SerializeTuple, Self::Error> {
+        Ok(SerializeSeq {
+            inner: Vec::with_capacity(len),
+        })
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Ok(SerializeTupleVariant {
+            key: Key::from(variant),
+            inner: Vec::with_capacity(len),
+        })
+    }
+
+    fn serialize_map(
+        self,
+        len: Option<usize>,
+    ) -> Result<Self::SerializeMap, Self::Error> {
+        Ok(SerializeMap {
+            keys: Vec::with_capacity(len.unwrap_or(0)),
+            values: Vec::with_capacity(len.unwrap_or(0)),
+        })
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Ok(SerializeMap {
+            keys: Vec::with_capacity(len),
+            values: Vec::with_capacity(len),
+        })
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Ok(SerializeMapVariant {
+            name: Key::from(variant),
+            keys: Vec::with_capacity(len),
+            values: Vec::with_capacity(len),
+        })
+    }
+}

--- a/crates/lib/src/types/value.rs
+++ b/crates/lib/src/types/value.rs
@@ -1,9 +1,10 @@
 use super::{Key, List, Map};
+use base64::prelude::*;
 use miette::Error;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
-use time::{format_description::well_known::Rfc3339, Duration, OffsetDateTime};
+use time::{Duration, OffsetDateTime};
 
 /// ValueKind is an enum that represents the different types of values that can be stored in a
 /// Value.
@@ -24,6 +25,21 @@ pub enum ValueKind {
     Null,
 }
 
+pub trait TryIntoValue {
+    type Error: std::error::Error + 'static;
+    fn try_into_value(self) -> Result<Value, Self::Error>;
+}
+
+impl<T> TryIntoValue for T
+where
+    T: serde::Serialize,
+{
+    type Error = super::ser::SerializeError;
+    fn try_into_value(self) -> Result<Value, Self::Error> {
+        self.serialize(super::ser::Serializer)
+    }
+}
+
 /// Value is a primitive value for each ValueKind. Resolution for a value could be a constant,
 /// for example, an Int(1), or a resolved value from a variable.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -42,99 +58,172 @@ pub enum Value {
     Duration(Duration),
 }
 
-impl From<serde_json::Value> for Value {
-    fn from(value: serde_json::Value) -> Self {
-        match value {
-            serde_json::Value::Null => Value::Null,
-            serde_json::Value::Bool(b) => Value::Bool(b),
-            serde_json::Value::Number(n) => {
-                if let Some(i) = n.as_i64() {
-                    Value::Int(i)
-                } else if let Some(u) = n.as_u64() {
-                    Value::Uint(u)
-                } else {
-                    Value::Double(n.as_f64().unwrap())
-                }
-            }
-            serde_json::Value::String(s) => Value::String(s),
-            serde_json::Value::Array(a) => {
-                if a.is_empty() {
-                    Value::List(List::new())
-                } else {
-                    Value::List(List::from(
-                        a.into_iter().map(Value::from).collect::<Vec<Value>>(),
-                    ))
-                }
-            }
-            serde_json::Value::Object(o) => {
-                if o.is_empty() {
-                    Value::Map(Map::new())
-                } else {
-                    Value::Map(Map::from(
-                        o.into_iter()
-                            .map(|(k, v)| (Key::from(k), Value::from(v)))
-                            .collect::<HashMap<Key, Value>>(),
-                    ))
-                }
-            }
-        }
+impl From<i8> for Value {
+    fn from(value: i8) -> Self {
+        Value::Int(value as i64)
     }
 }
 
-impl From<Value> for serde_json::Value {
+impl From<Value> for i8 {
     fn from(value: Value) -> Self {
         match value {
-            Value::Int(n) => serde_json::Value::Number(n.into()),
-            Value::Uint(n) => serde_json::Value::Number(n.into()),
-            Value::Double(n) => serde_json::to_value(n).unwrap(),
-            Value::String(s) => serde_json::Value::String(s),
-            Value::Bool(b) => serde_json::Value::Bool(b),
-            Value::Map(map) => serde_json::to_value(map).unwrap(),
-            Value::List(list) => serde_json::to_value(list).unwrap(),
-            Value::Bytes(b) => serde_json::Value::Array(
-                b.into_iter().map(|b| b.into()).collect(),
-            ),
-            Value::Null => serde_json::Value::Null,
-            Value::Timestamp(t) => {
-                serde_json::Value::String(t.format(&Rfc3339).unwrap())
-            }
-            Value::Duration(d) => serde_json::Value::String(d.to_string()),
+            Value::Int(n) => n as i8,
+            _ => panic!("Cannot convert {:?} to i8", value),
         }
     }
 }
 
-macro_rules! impl_owned_value_conversions {
-    ($($target_type: ty => $value_variant:path),* $(,)?) => {
-        $(
-            impl From<$target_type> for Value {
-                fn from(value: $target_type) -> Self {
-                    $value_variant(value)
-                }
-            }
-
-            impl From<Value> for $target_type {
-                fn from(value: Value) -> Self {
-                    match value {
-                        $value_variant(v) => v,
-                        _ => panic!("Invalid conversion from {:?} to {:?}", value, stringify!($target_type)),
-                    }
-                }
-            }
-        )*
+impl From<i16> for Value {
+    fn from(value: i16) -> Self {
+        Value::Int(value as i64)
     }
 }
 
-impl_owned_value_conversions! {
-    i64 => Value::Int,
-    u64 => Value::Uint,
-    f64 => Value::Double,
-    bool => Value::Bool,
-    String => Value::String,
-    Map => Value::Map,
-    List => Value::List,
-    Vec<u8> => Value::Bytes,
-    OffsetDateTime => Value::Timestamp,
-    Duration => Value::Duration,
+impl From<Value> for i16 {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Int(n) => n as i16,
+            _ => panic!("Cannot convert {:?} to i16", value),
+        }
+    }
+}
+
+impl From<i32> for Value {
+    fn from(value: i32) -> Self {
+        Value::Uint(value as u64)
+    }
+}
+
+impl From<Value> for i32 {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Int(n) => n as i32,
+            _ => panic!("Cannot convert {:?} to i32", value),
+        }
+    }
+}
+
+impl From<i64> for Value {
+    fn from(value: i64) -> Self {
+        Value::Int(value)
+    }
+}
+
+impl From<isize> for Value {
+    fn from(value: isize) -> Self {
+        Value::Int(value as i64)
+    }
+}
+
+impl From<Value> for isize {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Int(n) => n as isize,
+            _ => panic!("Cannot convert {:?} to isize", value),
+        }
+    }
+}
+
+impl From<Value> for i64 {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Int(n) => n,
+            _ => panic!("Cannot convert {:?} to i64", value),
+        }
+    }
+}
+
+impl From<u8> for Value {
+    fn from(value: u8) -> Self {
+        Value::Uint(value as u64)
+    }
+}
+
+impl From<Value> for u8 {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Uint(n) => n as u8,
+            _ => panic!("Cannot convert {:?} to u8", value),
+        }
+    }
+}
+
+impl From<u16> for Value {
+    fn from(value: u16) -> Self {
+        Value::Uint(value as u64)
+    }
+}
+
+impl From<Value> for u16 {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Uint(n) => n as u16,
+            _ => panic!("Cannot convert {:?} to u16", value),
+        }
+    }
+}
+
+impl From<u32> for Value {
+    fn from(value: u32) -> Self {
+        Value::Uint(value as u64)
+    }
+}
+
+impl From<Value> for u32 {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Uint(n) => n as u32,
+            _ => panic!("Cannot convert {:?} to u32", value),
+        }
+    }
+}
+
+impl From<u64> for Value {
+    fn from(value: u64) -> Self {
+        Value::Uint(value)
+    }
+}
+
+impl From<usize> for Value {
+    fn from(value: usize) -> Self {
+        Value::Uint(value as u64)
+    }
+}
+
+impl From<Value> for u64 {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Uint(n) => n,
+            _ => panic!("Cannot convert {:?} to u64", value),
+        }
+    }
+}
+
+impl From<f64> for Value {
+    fn from(value: f64) -> Self {
+        Value::Double(value)
+    }
+}
+
+impl From<Value> for f64 {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Double(n) => n,
+            _ => panic!("Cannot convert {:?} to f64", value),
+        }
+    }
+}
+
+impl From<String> for Value {
+    fn from(value: String) -> Self {
+        Value::String(value)
+    }
+}
+
+impl From<&String> for Value {
+    fn from(value: &String) -> Self {
+        Value::String(value.clone())
+    }
 }
 
 impl From<&str> for Value {
@@ -143,24 +232,142 @@ impl From<&str> for Value {
     }
 }
 
-impl<T> From<Vec<T>> for Value
-where
-    T: Into<Value>,
-{
-    fn from(value: Vec<T>) -> Self {
-        Value::List(List::from(value))
+impl From<Value> for String {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::String(s) => s,
+            _ => panic!("Cannot convert {:?} to String", value),
+        }
     }
 }
 
-impl<K, V> From<HashMap<K, V>> for Value
-where
-    K: Into<Key>,
-    V: Into<Value>,
-{
-    fn from(v: HashMap<K, V>) -> Value {
-        Value::Map(Map::from(v))
+impl From<bool> for Value {
+    fn from(value: bool) -> Self {
+        Value::Bool(value)
     }
 }
+
+impl From<Value> for bool {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Bool(b) => b,
+            _ => panic!("Cannot convert {:?} to bool", value),
+        }
+    }
+}
+
+impl From<Map> for Value {
+    fn from(value: Map) -> Self {
+        Value::Map(value)
+    }
+}
+
+impl From<HashMap<Key, Value>> for Value {
+    fn from(value: HashMap<Key, Value>) -> Self {
+        Value::Map(value.into())
+    }
+}
+
+impl From<List> for Value {
+    fn from(value: List) -> Self {
+        Value::List(value)
+    }
+}
+
+impl From<Vec<u8>> for Value {
+    fn from(value: Vec<u8>) -> Self {
+        Value::Bytes(value)
+    }
+}
+
+impl From<Value> for Vec<u8> {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Bytes(b) => b,
+            _ => panic!("Cannot convert {:?} to Vec<u8>", value),
+        }
+    }
+}
+
+impl From<&[u8]> for Value {
+    fn from(value: &[u8]) -> Self {
+        Value::Bytes(value.to_vec())
+    }
+}
+
+impl From<OffsetDateTime> for Value {
+    fn from(value: OffsetDateTime) -> Self {
+        Value::Timestamp(value)
+    }
+}
+
+impl From<Value> for OffsetDateTime {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Timestamp(t) => t,
+            _ => panic!("Cannot convert {:?} to OffsetDateTime", value),
+        }
+    }
+}
+
+impl From<Duration> for Value {
+    fn from(value: Duration) -> Self {
+        Value::Duration(value)
+    }
+}
+
+impl From<Value> for Duration {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Duration(d) => d,
+            _ => panic!("Cannot convert {:?} to Duration", value),
+        }
+    }
+}
+
+// impl From<Value> for serde_json::Value {
+//     fn from(value: Value) -> Self {
+//         match value {
+//             Value::Int(n) => serde_json::Value::Number(n.into()),
+//             Value::Uint(n) => serde_json::Value::Number(n.into()),
+//             Value::Double(n) => serde_json::to_value(n).unwrap(),
+//             Value::String(s) => serde_json::Value::String(s),
+//             Value::Bool(b) => serde_json::Value::Bool(b),
+//             Value::Map(map) => serde_json::to_value(map).unwrap(),
+//             Value::List(list) => serde_json::to_value(list).unwrap(),
+//             Value::Bytes(b) => serde_json::Value::Array(
+//                 b.into_iter().map(|b| b.into()).collect(),
+//             ),
+//             Value::Null => serde_json::Value::Null,
+//             Value::Timestamp(t) => {
+//                 serde_json::Value::String(t.format(&Rfc3339).unwrap())
+//             }
+//             Value::Duration(d) => serde_json::Value::String(d.to_string()),
+//         }
+//     }
+// }
+//
+// impl From<&Value> for serde_json::Value {
+//     fn from(value: &Value) -> Self {
+//         match value {
+//             Value::Int(n) => serde_json::Value::from(*n),
+//             Value::Uint(n) => serde_json::Value::from(*n),
+//             Value::Double(n) => serde_json::to_value(n).unwrap(),
+//             Value::String(s) => serde_json::Value::String(s.clone()),
+//             Value::Bool(b) => serde_json::Value::Bool(*b),
+//             Value::Map(map) => serde_json::to_value(map).unwrap(),
+//             Value::List(list) => serde_json::to_value(list).unwrap(),
+//             Value::Bytes(b) => {
+//                 serde_json::Value::String(BASE64_STANDARD.encode(b))
+//             }
+//             Value::Null => serde_json::Value::Null,
+//             Value::Timestamp(t) => {
+//                 serde_json::Value::String(t.format(&Rfc3339).unwrap())
+//             }
+//             Value::Duration(d) => serde_json::Value::String(d.to_string()),
+//         }
+//     }
+// }
 
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -172,7 +379,7 @@ impl fmt::Display for Value {
             Value::Bool(b) => write!(f, "{b}"),
             Value::Map(map) => write!(f, "{map}"),
             Value::List(list) => write!(f, "{list}"),
-            Value::Bytes(b) => write!(f, "{b:?}"),
+            Value::Bytes(b) => BASE64_STANDARD.encode(b).fmt(f),
             Value::Null => write!(f, "null"),
             Value::Timestamp(v) => write!(f, "{v}"),
             Value::Duration(v) => write!(f, "{v:?}"),


### PR DESCRIPTION
Implementing this can help pass down values that implement `Serialize` to the environment, as well as to take the result and deserialize it back to a type that implements `DeserializeOwned`.