### PR TITLE
Switch from Box for function to ARC so that environment builder can be a copy

### DIFF
--- a/crates/lib/examples/concurrency.rs
+++ b/crates/lib/examples/concurrency.rs
@@ -1,0 +1,41 @@
+use cellang::{Environment, EnvironmentBuilder, TokenTree, Value};
+use std::sync::Arc;
+use std::thread;
+
+fn main() {
+    let mut env = EnvironmentBuilder::default();
+    env.set_function(
+        "plus_two",
+        Arc::new(|env: &Environment, tokens: &[TokenTree]| {
+            if tokens.len() != 1 {
+                miette::bail!("Expected one argument");
+            }
+            let value = cellang::eval_ast(env, &tokens[0])?;
+            let result = match value.try_value()? {
+                Value::Int(n) => *n + 2,
+                Value::Uint(n) => (*n + 2) as i64,
+                Value::Double(n) => (*n + 2.0) as i64,
+                _ => miette::bail!("Expected a number"),
+            };
+
+            Ok(Value::Int(result))
+        }),
+    );
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let worker_env = env.clone();
+    let h = thread::spawn(move || {
+        let env = worker_env.build();
+        let val: i64 = cellang::eval(&env, "2.plus_two()")
+            .unwrap()
+            .try_into()
+            .unwrap();
+
+        tx.send(val).unwrap();
+    });
+
+    let value = rx.recv().unwrap();
+    h.join().unwrap();
+
+    assert_eq!(value, 4);
+}

--- a/crates/lib/examples/create_function.rs
+++ b/crates/lib/examples/create_function.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use cellang::{Environment, EnvironmentBuilder, List, Map, TokenTree, Value};
 use miette::Error;
 
@@ -52,7 +54,7 @@ fn main() {
     let mut env = EnvironmentBuilder::default();
 
     // Register the function
-    env.set_function("split", Box::new(split));
+    env.set_function("split", Arc::new(split));
 
     // Seal the environment so that it can be used for evaluation
     let env = env.build();

--- a/crates/lib/examples/user_role.rs
+++ b/crates/lib/examples/user_role.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use cellang::{Environment, EnvironmentBuilder, TokenTree, Value};
 use miette::Error;
 use serde::{Deserialize, Serialize};
@@ -13,7 +15,7 @@ fn main() {
     env.set_variable("users", users).unwrap();
 
     // Add a custom function to the environment
-    env.set_function("has_role", Box::new(has_role));
+    env.set_function("has_role", Arc::new(has_role));
 
     // Let's say the program tries to get the number of users with particular role
     let program = "size(users.filter(u, u.has_role(role)))";

--- a/crates/lib/src/functions.rs
+++ b/crates/lib/src/functions.rs
@@ -593,6 +593,8 @@ pub fn duration(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::{EnvironmentBuilder, Function, Parser};
 
@@ -600,23 +602,23 @@ mod tests {
 
     #[test]
     fn implement_functions() {
-        is_function(Box::new(size));
-        is_function(Box::new(type_fn));
-        is_function(Box::new(has));
-        is_function(Box::new(all));
-        is_function(Box::new(exists));
-        is_function(Box::new(exists_one));
-        is_function(Box::new(map));
-        is_function(Box::new(filter));
-        is_function(Box::new(contains));
-        is_function(Box::new(starts_with));
-        is_function(Box::new(matches));
-        is_function(Box::new(uint));
-        is_function(Box::new(int));
-        is_function(Box::new(string));
-        is_function(Box::new(dyn_fn));
-        is_function(Box::new(duration));
-        is_function(Box::new(timestamp));
+        is_function(Arc::new(size));
+        is_function(Arc::new(type_fn));
+        is_function(Arc::new(has));
+        is_function(Arc::new(all));
+        is_function(Arc::new(exists));
+        is_function(Arc::new(exists_one));
+        is_function(Arc::new(map));
+        is_function(Arc::new(filter));
+        is_function(Arc::new(contains));
+        is_function(Arc::new(starts_with));
+        is_function(Arc::new(matches));
+        is_function(Arc::new(uint));
+        is_function(Arc::new(int));
+        is_function(Arc::new(string));
+        is_function(Arc::new(dyn_fn));
+        is_function(Arc::new(duration));
+        is_function(Arc::new(timestamp));
     }
 
     #[test]

--- a/crates/lib/src/interpreter.rs
+++ b/crates/lib/src/interpreter.rs
@@ -420,6 +420,8 @@ enum Object<'a> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::environment::EnvironmentBuilder;
 
@@ -904,7 +906,7 @@ mod tests {
         let mut env = EnvironmentBuilder::default();
         env.set_function(
             "foo",
-            Box::new(|_env, args: &[TokenTree]| {
+            Arc::new(|_env, args: &[TokenTree]| {
                 Ok(Value::Int(args.len() as i64))
             }),
         );

--- a/crates/lib/src/types/mod.rs
+++ b/crates/lib/src/types/mod.rs
@@ -5,6 +5,8 @@ pub mod map;
 mod ser;
 pub mod value;
 
+use std::sync::Arc;
+
 pub use self::duration::*;
 pub use self::list::*;
 pub use self::map::*;
@@ -16,8 +18,9 @@ use crate::parser::TokenTree;
 use crate::Environment;
 
 /// Function is a wrapper for a dynamic function that can be registered in the environment.
-pub type Function =
-    Box<dyn Fn(&Environment, &[TokenTree]) -> Result<Value, Error>>;
+pub type Function = Arc<
+    dyn Fn(&Environment, &[TokenTree]) -> Result<Value, Error> + Send + Sync,
+>;
 
 /// Function is a wrapper for turning Value into any type that implements DeserializeOwned.
 pub fn try_from_value<T>(value: Value) -> Result<T, Error>

--- a/crates/lib/src/types/value.rs
+++ b/crates/lib/src/types/value.rs
@@ -1,6 +1,7 @@
 use super::{deserialize_duration, serialize_duration, Key, List, Map};
 use base64::prelude::*;
 use miette::Error;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::{collections::HashMap, str::FromStr};
@@ -514,6 +515,13 @@ impl Value {
             Value::Timestamp(_) => ValueKind::Timestamp,
             Value::Duration(_) => ValueKind::Duration,
         }
+    }
+
+    pub fn try_into<T>(self) -> Result<T, Error>
+    where
+        T: DeserializeOwned,
+    {
+        crate::try_from_value(self)
     }
 
     pub fn plus(&self, other: &Value) -> Result<Value, Error> {


### PR DESCRIPTION
Allow builder to be cloned so that environment can be built in another thread. The clone would clone variables map, clone the function names and references to functions. 