### PR TITLE
Add convenience function for root environment with empty variables

### DIFF
--- a/crates/lib/examples/simple.rs
+++ b/crates/lib/examples/simple.rs
@@ -1,9 +1,8 @@
-use cellang::EnvironmentBuilder;
+use cellang::Environment;
 
 fn main() {
     // Create a new environment with functions but without variables
-    let env = EnvironmentBuilder::default();
-    let env = env.build();
+    let env = Environment::root();
 
     // Evaluate a simple expression
     let value = cellang::eval(&env, "1 + 2 * 3").unwrap();
@@ -17,8 +16,7 @@ fn main() {
     assert_eq!(value, true.into());
 
     // Evaluate a simple expression with macros
-    let env = EnvironmentBuilder::default();
-    let env = env.build();
+    let env = Environment::root();
     let value =
         cellang::eval(&env, "'Hello, World!'.startsWith('Hello')").unwrap();
     assert_eq!(value, true.into());


### PR DESCRIPTION
Add a convenience function to use root environment. This can be handy in situations where variable map is built, and you only want to set it in the environment. Then use `Environment::root()` that instantiates the root environment with only functions, and later use `set_variables` to populate the pre-built variable map.