### PR TITLE
Implement `dyn` logic, fix the function call and change the API to try_from for Map since keys must be of the same type

### DIFF
--- a/crates/lib/examples/create_function.rs
+++ b/crates/lib/examples/create_function.rs
@@ -46,7 +46,7 @@ fn split(env: &Environment, tokens: &[TokenTree]) -> Result<Value, Error> {
         .collect::<Vec<Value>>();
 
     // Now, return the type List of strings
-    Ok(Value::List(result.into()))
+    Ok(Value::List(result.try_into().unwrap()))
 }
 
 fn main() {
@@ -61,7 +61,10 @@ fn main() {
 
     // Evaluate a simple expression
     let value = cellang::eval(&env, "'a,b,c'.split(',')").unwrap();
-    assert_eq!(value, Value::List(List::from(vec!["a", "b", "c",])));
+    assert_eq!(
+        value,
+        Value::List(List::try_from(vec!["a", "b", "c",]).unwrap())
+    );
 
     // Evaluate a simple expression with variables
     let mut variables = Map::new();
@@ -69,5 +72,8 @@ fn main() {
     let mut env = env.child();
     env.set_variables(&variables);
     let value = cellang::eval(&env, "x.split(',')").unwrap();
-    assert_eq!(value, Value::List(List::from(vec!["a", "b", "c",])));
+    assert_eq!(
+        value,
+        Value::List(List::try_from(vec!["a", "b", "c",]).unwrap())
+    );
 }

--- a/crates/lib/src/environment.rs
+++ b/crates/lib/src/environment.rs
@@ -128,7 +128,6 @@ fn default_functions() -> &'static HashMap<String, Function> {
             "timestamp".to_string(),
             Arc::new(functions::timestamp) as Function,
         );
-        m.insert("dyn".to_string(), Arc::new(functions::dyn_fn) as Function);
         m.insert(
             "duration".to_string(),
             Arc::new(functions::duration) as Function,

--- a/crates/lib/src/functions.rs
+++ b/crates/lib/src/functions.rs
@@ -610,19 +610,6 @@ pub fn duration(
     Ok(v)
 }
 
-pub fn dyn_fn(env: &Environment, tokens: &[TokenTree]) -> Result<Value, Error> {
-    if tokens.len() != 1 {
-        miette::bail!(
-            "expected 1 argument, found {}\ntokens: {tokens:?}",
-            tokens.len()
-        );
-    }
-
-    let v = eval_ast(env, &tokens[0])?.to_value()?;
-
-    Ok(Value::Dyn(v.into()))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -647,7 +634,6 @@ mod tests {
         is_function(Arc::new(uint));
         is_function(Arc::new(int));
         is_function(Arc::new(string));
-        is_function(Arc::new(dyn_fn));
         is_function(Arc::new(duration));
         is_function(Arc::new(timestamp));
     }

--- a/crates/lib/src/functions.rs
+++ b/crates/lib/src/functions.rs
@@ -605,7 +605,10 @@ pub fn duration(
 
 pub fn dyn_fn(env: &Environment, tokens: &[TokenTree]) -> Result<Value, Error> {
     if tokens.len() != 1 {
-        miette::bail!("expected 1 argument, found {}", tokens.len());
+        miette::bail!(
+            "expected 1 argument, found {}\ntokens: {tokens:?}",
+            tokens.len()
+        );
     }
 
     let v = eval_ast(env, &tokens[0])?.to_value()?;

--- a/crates/lib/src/functions.rs
+++ b/crates/lib/src/functions.rs
@@ -1,4 +1,5 @@
 use crate::{
+    dynamic::Dyn,
     eval_ast,
     parser::{Atom, Op, TokenTree},
     types::{Duration, List, Map},
@@ -52,6 +53,19 @@ pub fn type_fn(
         Value::Null => "null".into(),
         Value::Timestamp(_) => "timestamp".into(),
         Value::Duration(_) => "duration".into(),
+        Value::Dyn(ref v) => match v {
+            Dyn::Int(_) => "dyn(int)".into(),
+            Dyn::Uint(_) => "dyn(uint)".into(),
+            Dyn::Double(_) => "dyn(double)".into(),
+            Dyn::String(_) => "dyn(string)".into(),
+            Dyn::Bool(_) => "dyn(bool)".into(),
+            Dyn::Map(_) => "dyn(map)".into(),
+            Dyn::List(_) => "dyn(list)".into(),
+            Dyn::Bytes(_) => "dyn(bytes)".into(),
+            Dyn::Null => "dyn(null)".into(),
+            Dyn::Timestamp(_) => "dyn(timestamp)".into(),
+            Dyn::Duration(_) => "dyn(duration)".into(),
+        },
     };
 
     Ok(v)
@@ -473,10 +487,7 @@ pub fn uint(env: &Environment, tokens: &[TokenTree]) -> Result<Value, Error> {
     let v = match eval_ast(env, &tokens[0])?.to_value()? {
         Value::Int(i) => Value::Uint(u64::try_from(i).into_diagnostic()?),
         Value::Uint(u) => Value::Uint(u),
-        Value::Double(d) => {
-            let i = d as i64;
-            Value::Uint(u64::try_from(i).into_diagnostic()?)
-        }
+        Value::Double(d) => Value::Uint(d.round() as u64),
         Value::String(s) => match s.parse::<u64>() {
             Ok(u) => Value::Uint(u),
             Err(_) => miette::bail!("Invalid type for uint: {:?}", tokens[0]),
@@ -502,6 +513,7 @@ pub fn int(env: &Environment, tokens: &[TokenTree]) -> Result<Value, Error> {
             Err(_) => miette::bail!("Invalid type for int: {:?}", tokens[0]),
         },
         Value::Timestamp(t) => Value::Int(t.unix_timestamp()),
+        Value::Dyn(d) => d.try_as_i64()?.into(),
         _ => miette::bail!("Invalid type for int: {:?}", tokens[0]),
     };
 
@@ -598,7 +610,7 @@ pub fn dyn_fn(env: &Environment, tokens: &[TokenTree]) -> Result<Value, Error> {
 
     let v = eval_ast(env, &tokens[0])?.to_value()?;
 
-    Ok(v)
+    Ok(Value::Dyn(v.into()))
 }
 
 #[cfg(test)]

--- a/crates/lib/src/functions.rs
+++ b/crates/lib/src/functions.rs
@@ -25,6 +25,13 @@ pub fn size(env: &Environment, tokens: &[TokenTree]) -> Result<Value, Error> {
         Value::String(s) => Value::Int(s.len() as i64),
         Value::List(list) => Value::Int(list.len() as i64),
         Value::Map(map) => Value::Int(map.len() as i64),
+        Value::Dyn(d) => match d {
+            Dyn::Bytes(b) => Value::Int(b.len() as i64),
+            Dyn::String(s) => Value::Int(s.len() as i64),
+            Dyn::List(list) => Value::Int(list.len() as i64),
+            Dyn::Map(map) => Value::Int(map.len() as i64),
+            _ => miette::bail!("Invalid type for size: {:?}", tokens[0]),
+        },
         _ => miette::bail!("Invalid type for size: {:?}", tokens[0]),
     };
 

--- a/crates/lib/src/functions.rs
+++ b/crates/lib/src/functions.rs
@@ -520,7 +520,7 @@ pub fn int(env: &Environment, tokens: &[TokenTree]) -> Result<Value, Error> {
             Err(_) => miette::bail!("Invalid type for int: {:?}", tokens[0]),
         },
         Value::Timestamp(t) => Value::Int(t.unix_timestamp()),
-        Value::Dyn(d) => d.try_as_i64()?.into(),
+        Value::Dyn(d) => d.try_into_i64()?.into(),
         _ => miette::bail!("Invalid type for int: {:?}", tokens[0]),
     };
 

--- a/crates/lib/src/interpreter.rs
+++ b/crates/lib/src/interpreter.rs
@@ -506,6 +506,14 @@ mod tests {
                     .unwrap()
             )
         );
+        assert_eq!(
+            eval(&env, "dyn([2u, 3u]) + [1]").expect("dyn([2u, 3u]) + [1]"),
+            Value::List(
+                vec![Value::Int(2), Value::Int(3), Value::Int(1)]
+                    .try_into()
+                    .unwrap()
+            )
+        );
     }
 
     #[test]

--- a/crates/lib/src/interpreter.rs
+++ b/crates/lib/src/interpreter.rs
@@ -1162,6 +1162,11 @@ mod tests {
             eval(&env, "dyn({'a': 'b', 2: 3})['a']")
                 .expect("dyn({'a': 'b', 2: 3})['a']"),
             Value::from("b")
+        );
+        assert_eq!(
+            eval(&env, "dyn({'a': 'b', 2: 3})[2]")
+                .expect("dyn({'a': 'b', 2: 3})[2]"),
+            Value::Int(3)
         )
     }
 

--- a/crates/lib/src/interpreter.rs
+++ b/crates/lib/src/interpreter.rs
@@ -105,6 +105,12 @@ pub fn eval_cons<'a>(
                     }
                     Value::Dyn(Dyn::List(list))
                 }
+                TokenTree::Call { func, args } => {
+                    let lhs = eval_ast(env, func)?;
+                    let f = lhs.try_function()?;
+                    let value = f(env, args.as_ref())?;
+                    Value::Dyn(value.into())
+                }
                 _ => miette::bail!(
                     "Expected atom or list, found {:?}",
                     tokens[0]

--- a/crates/lib/src/interpreter.rs
+++ b/crates/lib/src/interpreter.rs
@@ -438,7 +438,7 @@ mod tests {
     }
 
     #[test]
-    fn test_eval_plus() {
+    fn test_eval_basic_plus() {
         let env = EnvironmentBuilder::default();
         let env = env.build();
         assert_eq!(eval(&env, "1 + 2").expect("1 + 2"), Value::Int(3));
@@ -450,6 +450,61 @@ mod tests {
         assert_eq!(
             eval(&env, "\"hello\" + \"world\"").expect("\"hello\" + \"world\""),
             "helloworld".into()
+        );
+        assert_eq!(
+            eval(&env, "[1] + [2, 3]").expect("[1] + [2, 3]"),
+            Value::List(
+                vec![Value::Int(1), Value::Int(2), Value::Int(3)]
+                    .try_into()
+                    .unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn test_eval_dyn_plus() {
+        let env = EnvironmentBuilder::default();
+        let env = env.build();
+        assert_eq!(
+            eval(&env, "1 + dyn(2)").expect("1 + dyn(2)"),
+            Value::Int(3),
+            "1 + dyn(2)"
+        );
+        assert_eq!(
+            eval(&env, "1 + dyn(2u)").expect("1 + dyn(2u)"),
+            Value::Int(3),
+            "1 + dyn(2u)"
+        );
+        assert_eq!(
+            eval(&env, "1 + dyn(2.0)").expect("1 + dyn(2.0)"),
+            Value::Int(3),
+            "1 + dyn(2u)"
+        );
+        assert_eq!(
+            eval(&env, "1 + dyn(\"2\")").expect("1 + dyn(\"2\")"),
+            Value::Int(3),
+            "1 + dyn(\"2\")"
+        );
+        assert_eq!(
+            eval(&env, "\"1\" + dyn(2)").expect("\"1\" + dyn(2)"),
+            "12".into(),
+            "\"1\" + dyn(2)"
+        );
+        assert_eq!(
+            eval(&env, "[1] + dyn([2, 3])").expect("[1] + dyn([2, 3])"),
+            Value::List(
+                vec![Value::Int(1), Value::Int(2), Value::Int(3)]
+                    .try_into()
+                    .unwrap()
+            )
+        );
+        assert_eq!(
+            eval(&env, "[1] + dyn([2u, 3u])").expect("[1] + dyn([2u, 3u])"),
+            Value::List(
+                vec![Value::Int(1), Value::Int(2), Value::Int(3)]
+                    .try_into()
+                    .unwrap()
+            )
         );
     }
 

--- a/crates/lib/src/interpreter.rs
+++ b/crates/lib/src/interpreter.rs
@@ -428,8 +428,7 @@ mod tests {
 
     #[test]
     fn test_eval_primitives() {
-        let env = EnvironmentBuilder::default();
-        let env = env.build();
+        let env = Environment::root();
         assert_eq!(eval(&env, "42").expect("42"), Value::Int(42));
         assert_eq!(eval(&env, "true").expect("true"), Value::Bool(true));
         assert_eq!(eval(&env, "false").expect("false"), Value::Bool(false));
@@ -439,8 +438,7 @@ mod tests {
 
     #[test]
     fn test_eval_basic_plus() {
-        let env = EnvironmentBuilder::default();
-        let env = env.build();
+        let env = Environment::root();
         assert_eq!(eval(&env, "1 + 2").expect("1 + 2"), Value::Int(3));
         assert_eq!(eval(&env, "1u + 2u").expect("1u + 2u"), Value::Uint(3));
         assert_eq!(
@@ -463,8 +461,7 @@ mod tests {
 
     #[test]
     fn test_eval_dyn_plus() {
-        let env = EnvironmentBuilder::default();
-        let env = env.build();
+        let env = Environment::root();
         assert_eq!(
             eval(&env, "1 + dyn(2)").expect("1 + dyn(2)"),
             Value::Int(3),
@@ -522,8 +519,7 @@ mod tests {
 
     #[test]
     fn test_eval_basic_minus() {
-        let env = EnvironmentBuilder::default();
-        let env = env.build();
+        let env = Environment::root();
         assert_eq!(eval(&env, "1 - 2").expect("1 - 2"), Value::Int(-1));
         assert_eq!(eval(&env, "2u - 1u").expect("2u - 1u"), Value::Uint(1));
         assert_eq!(
@@ -534,8 +530,7 @@ mod tests {
 
     #[test]
     fn test_eval_dyn_minus() {
-        let env = EnvironmentBuilder::default();
-        let env = env.build();
+        let env = Environment::root();
         assert_eq!(
             eval(&env, "1 - dyn(2)").expect("1 - dyn(2)"),
             Value::Int(-1),
@@ -568,8 +563,7 @@ mod tests {
 
     #[test]
     fn test_eval_multiply() {
-        let env = EnvironmentBuilder::default();
-        let env = env.build();
+        let env = Environment::root();
         assert_eq!(eval(&env, "2 * 3").expect("2 * 3"), Value::Int(6));
         assert_eq!(eval(&env, "2u * 3u").expect("2u * 3u"), Value::Uint(6));
         assert_eq!(
@@ -580,8 +574,7 @@ mod tests {
 
     #[test]
     fn test_eval_devide() {
-        let env = EnvironmentBuilder::default();
-        let env = env.build();
+        let env = Environment::root();
         assert_eq!(eval(&env, "6 / 3").expect("6 / 3"), Value::Int(2));
         assert_eq!(eval(&env, "6u / 3u").expect("6u / 3u"), Value::Uint(2));
         assert_eq!(
@@ -592,8 +585,7 @@ mod tests {
 
     #[test]
     fn test_eval_and() {
-        let env = EnvironmentBuilder::default();
-        let env = env.build();
+        let env = Environment::root();
         assert_eq!(
             eval(&env, "true && false").expect("true && false"),
             Value::Bool(false)
@@ -606,8 +598,7 @@ mod tests {
 
     #[test]
     fn test_eval_or() {
-        let env = EnvironmentBuilder::default();
-        let env = env.build();
+        let env = Environment::root();
         assert_eq!(
             eval(&env, "false || true").expect("false || true"),
             Value::Bool(true)
@@ -620,8 +611,7 @@ mod tests {
 
     #[test]
     fn test_eval_equal_equal() {
-        let env = EnvironmentBuilder::default();
-        let env = env.build();
+        let env = Environment::root();
         assert_eq!(eval(&env, "1 == 1").expect("1 == 1"), Value::Bool(true));
         assert_eq!(eval(&env, "1 == 2").expect("1 == 2"), Value::Bool(false));
         assert_eq!(
@@ -662,8 +652,7 @@ mod tests {
 
     #[test]
     fn test_not_equal() {
-        let env = EnvironmentBuilder::default();
-        let env = env.build();
+        let env = Environment::root();
         assert_eq!(eval(&env, "1 != 1").expect("1 != 1"), Value::Bool(false));
         assert_eq!(eval(&env, "1 != 2").expect("1 != 2"), Value::Bool(true));
         assert_eq!(
@@ -704,8 +693,7 @@ mod tests {
 
     #[test]
     fn test_eval_basic_greater() {
-        let env = EnvironmentBuilder::default();
-        let env = env.build();
+        let env = Environment::root();
         assert_eq!(eval(&env, "2 > 1").expect("2 > 1"), Value::Bool(true));
         assert_eq!(eval(&env, "1 > 2").expect("1 > 2"), Value::Bool(false));
         assert_eq!(eval(&env, "2u > 1u").expect("2u > 1u"), Value::Bool(true));
@@ -738,9 +726,8 @@ mod tests {
     }
 
     #[test]
-    fn test_eval_greater_equal() {
-        let env = EnvironmentBuilder::default();
-        let env = env.build();
+    fn test_eval_basic_greater_equal() {
+        let env = Environment::root();
         assert_eq!(eval(&env, "2 >= 1").expect("2 >= 1"), Value::Bool(true));
         assert_eq!(eval(&env, "1 >= 2").expect("1 >= 2"), Value::Bool(false));
         assert_eq!(eval(&env, "1 >= 1").expect("1 >= 1"), Value::Bool(true));
@@ -771,9 +758,25 @@ mod tests {
     }
 
     #[test]
-    fn test_eval_less() {
-        let env = EnvironmentBuilder::default();
-        let env = env.build();
+    fn test_eval_dyn_greater_equal() {
+        let env = Environment::root();
+        assert_eq!(
+            eval(&env, "dyn(2u) >= 1").expect("dyn(2u) >= 1"),
+            Value::Bool(true)
+        );
+        assert_eq!(
+            eval(&env, "2 >= dyn(1u)").expect("2 >= dyn(1u)"),
+            Value::Bool(true)
+        );
+        assert_eq!(
+            eval(&env, "dyn(2u) >= dyn(1u)").expect("dyn(2u) >= dyn(1u)"),
+            Value::Bool(true)
+        );
+    }
+
+    #[test]
+    fn test_eval_basic_less() {
+        let env = Environment::root();
         assert_eq!(eval(&env, "1 < 2").expect("1 < 2"), Value::Bool(true));
         assert_eq!(eval(&env, "2 < 1").expect("2 < 1"), Value::Bool(false));
         assert_eq!(eval(&env, "1u < 2u").expect("1u < 2u"), Value::Bool(true));
@@ -789,9 +792,25 @@ mod tests {
     }
 
     #[test]
-    fn test_eval_less_equal() {
-        let env = EnvironmentBuilder::default();
-        let env = env.build();
+    fn test_eval_dyn_less() {
+        let env = Environment::root();
+        assert_eq!(
+            eval(&env, "dyn(1u) < 2").expect("dyn(1u) < 2"),
+            Value::Bool(true)
+        );
+        assert_eq!(
+            eval(&env, "1 < dyn(2u)").expect("1 < dyn(2u)"),
+            Value::Bool(true)
+        );
+        assert_eq!(
+            eval(&env, "dyn(1u) < dyn(2u)").expect("dyn(1u) < dyn(2u)"),
+            Value::Bool(true)
+        );
+    }
+
+    #[test]
+    fn test_eval_basic_less_equal() {
+        let env = Environment::root();
         assert_eq!(eval(&env, "1 <= 2").expect("1 <= 2"), Value::Bool(true));
         assert_eq!(eval(&env, "2 <= 1").expect("2 <= 1"), Value::Bool(false));
         assert_eq!(eval(&env, "1 <= 1").expect("1 <= 1"), Value::Bool(true));
@@ -822,25 +841,59 @@ mod tests {
     }
 
     #[test]
-    fn test_eval_mod() {
-        let env = EnvironmentBuilder::default();
-        let env = env.build();
+    fn test_eval_dyn_less_equal() {
+        let env = Environment::root();
+        assert_eq!(
+            eval(&env, "dyn(1u) <= 2").expect("dyn(1u) <= 2"),
+            Value::Bool(true)
+        );
+        assert_eq!(
+            eval(&env, "1 <= dyn(2u)").expect("1 <= dyn(2u)"),
+            Value::Bool(true)
+        );
+        assert_eq!(
+            eval(&env, "dyn(1u) <= dyn(2u)").expect("dyn(1u) <= dyn(2u)"),
+            Value::Bool(true)
+        );
+    }
+
+    #[test]
+    fn test_eval_basic_mod() {
+        let env = Environment::root();
         assert_eq!(eval(&env, "5 % 2").expect("5 % 2"), Value::Int(1));
         assert_eq!(eval(&env, "5u % 2u").expect("5u % 2u"), Value::Uint(1));
     }
 
     #[test]
+    fn test_eval_dyn_mod() {
+        let env = Environment::root();
+        assert_eq!(
+            eval(&env, "5 % dyn(2)").expect("5 % dyn(2)"),
+            Value::Int(1),
+            "5 % dyn(2)"
+        );
+        assert_eq!(
+            eval(&env, "5u % dyn(2u)").expect("5u % dyn(2u)"),
+            Value::Uint(1),
+            "5u % dyn(2u)"
+        );
+        assert_eq!(
+            eval(&env, "dyn(5) % 2").expect("dyn(5) % 2"),
+            Value::Int(1),
+            "dyn(5) % 2"
+        );
+    }
+
+    #[test]
     fn test_eval_not() {
-        let env = EnvironmentBuilder::default();
-        let env = env.build();
+        let env = Environment::root();
         assert_eq!(eval(&env, "!true").expect("!true"), Value::Bool(false));
         assert_eq!(eval(&env, "!false").expect("!false"), Value::Bool(true));
     }
 
     #[test]
     fn test_list() {
-        let env = EnvironmentBuilder::default();
-        let env = env.build();
+        let env = Environment::root();
         assert_eq!(eval(&env, "[]").expect("[]"), Value::List(List::new()));
         assert_eq!(
             eval(&env, "[1, 2, 3]").expect("[1, 2, 3]"),

--- a/crates/lib/src/interpreter.rs
+++ b/crates/lib/src/interpreter.rs
@@ -514,10 +514,14 @@ mod tests {
                     .unwrap()
             )
         );
+        assert_eq!(
+            eval(&env, "dyn(1u) + dyn(2u)").expect("dyn(1u) + dyn(2u)"),
+            Value::Uint(3)
+        );
     }
 
     #[test]
-    fn test_eval_minus() {
+    fn test_eval_basic_minus() {
         let env = EnvironmentBuilder::default();
         let env = env.build();
         assert_eq!(eval(&env, "1 - 2").expect("1 - 2"), Value::Int(-1));
@@ -525,6 +529,40 @@ mod tests {
         assert_eq!(
             eval(&env, "1.0 - 2.0").expect("1.0 - 2.0"),
             Value::Double(-1.0)
+        );
+    }
+
+    #[test]
+    fn test_eval_dyn_minus() {
+        let env = EnvironmentBuilder::default();
+        let env = env.build();
+        assert_eq!(
+            eval(&env, "1 - dyn(2)").expect("1 - dyn(2)"),
+            Value::Int(-1),
+            "1 - dyn(2)"
+        );
+
+        assert_eq!(
+            eval(&env, "1 - dyn(2u)").expect("1 - dyn(2u)"),
+            Value::Int(-1),
+            "1 - dyn(2u)"
+        );
+        assert_eq!(
+            eval(&env, "dyn(1u) - 2").expect("dyn(1u) - 2"),
+            Value::Int(-1),
+            "dyn(1u) - 2"
+        );
+
+        assert_eq!(
+            eval(&env, "1 - dyn(2.0)").expect("1 - dyn(2.0)"),
+            Value::Int(-1),
+            "1 - dyn(2u)"
+        );
+
+        assert_eq!(
+            eval(&env, "1 - dyn(\"2\")").expect("1 - dyn(\"2\")"),
+            Value::Int(-1),
+            "1 - dyn(\"2\")"
         );
     }
 
@@ -665,7 +703,7 @@ mod tests {
     }
 
     #[test]
-    fn test_eval_greater() {
+    fn test_eval_basic_greater() {
         let env = EnvironmentBuilder::default();
         let env = env.build();
         assert_eq!(eval(&env, "2 > 1").expect("2 > 1"), Value::Bool(true));
@@ -679,6 +717,23 @@ mod tests {
         assert_eq!(
             eval(&env, "1.0 > 2.0").expect("1.0 > 2.0"),
             Value::Bool(false)
+        );
+    }
+
+    #[test]
+    fn test_eval_dyn_greater() {
+        let env = Environment::root();
+        assert_eq!(
+            eval(&env, "dyn(2) > 1").expect("dyn(2) > 1"),
+            Value::Bool(true)
+        );
+        assert_eq!(
+            eval(&env, "2 > dyn(1u)").expect("2 > dyn(1u)"),
+            Value::Bool(true)
+        );
+        assert_eq!(
+            eval(&env, "dyn(2u) > dyn(1u)").expect("dyn(2u) > dyn(1u)"),
+            Value::Bool(true)
         );
     }
 

--- a/crates/lib/src/lexer.rs
+++ b/crates/lib/src/lexer.rs
@@ -1432,6 +1432,19 @@ mod tests {
     }
 
     #[test]
+    fn test_dyn() {
+        let mut lexer = Lexer::new("dyn(1u)");
+        let token = lexer.next().unwrap().unwrap();
+        assert_eq!(token.ty, TokenType::Dyn);
+        let token = lexer.next().unwrap().unwrap();
+        assert_eq!(token.ty, TokenType::LeftParen);
+        let token = lexer.next().unwrap().unwrap();
+        assert_eq!(token.ty, TokenType::Uint(1));
+        let token = lexer.next().unwrap().unwrap();
+        assert_eq!(token.ty, TokenType::RightParen);
+    }
+
+    #[test]
     fn test_scan_str() {
         let tripple_delim = [r#"""""#, "'''"];
         let single_delim = ['"', '\''];

--- a/crates/lib/src/lexer.rs
+++ b/crates/lib/src/lexer.rs
@@ -93,6 +93,7 @@ pub enum TokenType {
     Namespace,
     Void,
     While,
+    Dyn,
 }
 
 impl fmt::Display for TokenType {
@@ -151,6 +152,7 @@ impl fmt::Display for TokenType {
             TokenType::Var => write!(f, "'var'"),
             TokenType::Void => write!(f, "'void'"),
             TokenType::While => write!(f, "'while'"),
+            TokenType::Dyn => write!(f, "'dyn'"),
         }
     }
 }
@@ -237,6 +239,7 @@ impl fmt::Display for Token<'_> {
             TokenType::Plus => write!(f, "PLUS {origin} nil"),
             TokenType::Minus => write!(f, "MINUS {origin} nil"),
             TokenType::Semicolon => write!(f, "SEMICOLON {origin} nil"),
+            TokenType::Dyn => write!(f, "DYN {origin} nil"),
             TokenType::String => {
                 write!(f, "STRING {origin} {}", Token::unescape(origin))
             }
@@ -612,12 +615,21 @@ impl<'src> Iterator for Lexer<'src> {
                         None => TokenType::Ident,
                     };
 
-                    Some(Ok(Token {
-                        ty,
-                        line: self.line,
-                        offset: c_at,
-                        origin: literal,
-                    }))
+                    if literal == "dyn" {
+                        Some(Ok(Token {
+                            ty: TokenType::Dyn,
+                            line: self.line,
+                            offset: c_at,
+                            origin: literal,
+                        }))
+                    } else {
+                        Some(Ok(Token {
+                            ty,
+                            line: self.line,
+                            offset: c_at,
+                            origin: literal,
+                        }))
+                    }
                 }
                 Started::DecimalNumber => {
                     enum State {

--- a/crates/lib/src/parser.rs
+++ b/crates/lib/src/parser.rs
@@ -1067,6 +1067,26 @@ mod tests {
 
     #[test]
     fn test_inline_function_call() {
+        let input = "1 + size(2u)";
+        let mut parser = Parser::new(input);
+        let tree = parser.parse().unwrap();
+        assert_eq!(
+            tree,
+            TokenTree::Cons(
+                Op::Plus,
+                vec![
+                    TokenTree::Atom(Atom::Int(1)),
+                    TokenTree::Call {
+                        func: Box::new(TokenTree::Atom(Atom::Ident("size"))),
+                        args: vec![TokenTree::Atom(Atom::Uint(2))],
+                    },
+                ]
+            )
+        );
+    }
+
+    #[test]
+    fn test_inline_dyn_call() {
         let input = "1 + dyn(2u)";
         let mut parser = Parser::new(input);
         let tree = parser.parse().unwrap();

--- a/crates/lib/src/parser.rs
+++ b/crates/lib/src/parser.rs
@@ -85,6 +85,22 @@ impl<'src> Parser<'src> {
                 ..
             } => TokenTree::Atom(Atom::Bool(false)),
 
+            // dyn
+            Token {
+                ty: TokenType::Dyn, ..
+            } => {
+                self.lexer.expect(
+                    TokenType::LeftParen,
+                    "Expected opening parenthesis after dyn",
+                )?;
+                let expr = self.parse_expr(0)?;
+                self.lexer.expect(
+                    TokenType::RightParen,
+                    "Expected closing parenthesis after dyn",
+                )?;
+                TokenTree::Cons(Op::Dyn, vec![expr])
+            }
+
             // groups
             Token {
                 ty: TokenType::LeftParen,
@@ -490,6 +506,7 @@ pub enum Op {
     Group,
     Map,
     List,
+    Dyn,
 }
 
 impl fmt::Display for Op {
@@ -520,6 +537,7 @@ impl fmt::Display for Op {
             Op::Map => "{map}",
             Op::List => "[list]",
             Op::Mod => "%",
+            Op::Dyn => "dyn",
         };
         write!(f, "{}", s)
     }
@@ -1058,10 +1076,10 @@ mod tests {
                 Op::Plus,
                 vec![
                     TokenTree::Atom(Atom::Int(1)),
-                    TokenTree::Call {
-                        func: Box::new(TokenTree::Atom(Atom::Ident("dyn"))),
-                        args: vec![TokenTree::Atom(Atom::Uint(2))],
-                    },
+                    TokenTree::Cons(
+                        Op::Dyn,
+                        vec![TokenTree::Atom(Atom::Uint(2))],
+                    ),
                 ]
             )
         );

--- a/crates/lib/src/types/dynamic.rs
+++ b/crates/lib/src/types/dynamic.rs
@@ -213,54 +213,6 @@ impl Dyn {
             ValueType::Dyn => miette::bail!("Failed to convert to dyn"),
         }
     }
-
-    pub fn plus(&self, other: &Value) -> Result<Value, Error> {
-        match other {
-            Value::Int(n) => Ok(Value::Int(self.try_as_i64()? + n)),
-            Value::Uint(n) => Ok(Value::Uint(self.try_as_uint()? + n)),
-            Value::Double(n) => Ok(Value::Double(self.try_as_double()? + n)),
-            Value::String(s) => {
-                Ok(Value::String(format!("{}{}", self.try_as_string()?, s)))
-            }
-            Value::Bytes(b) => {
-                let mut bytes = self.try_as_bytes()?;
-                bytes.extend_from_slice(b);
-                Ok(Value::Bytes(bytes))
-            }
-            Value::List(list) => {
-                let mut base = self.try_as_list_of(ValueType::ListOf {
-                    element_type: list.element_type().map(Box::new),
-                })?;
-
-                base.extend(list.clone());
-                Ok(Value::List(base))
-            }
-            Value::Timestamp(v) => {
-                let base = match self {
-                    Dyn::Duration(v) => *v,
-                    _ => miette::bail!("Failed to add timestamp"),
-                };
-
-                Ok(Value::Timestamp(*v + base))
-            }
-            Value::Duration(v) => match self {
-                Dyn::Duration(d) => Ok(Value::Duration(*v + *d)),
-                Dyn::Timestamp(t) => Ok(Value::Timestamp(*t + *v)),
-                _ => miette::bail!("Failed to add duration"),
-            },
-            Value::Dyn(_) => {
-                // Use self as a base
-                let s: Value = self.clone().try_into()?;
-                s.plus(other)
-            }
-
-            _ => miette::bail!(
-                "Invalid types for addition, lhs={:?}, rhs={:?}",
-                self,
-                other
-            ),
-        }
-    }
 }
 
 impl fmt::Display for Dyn {

--- a/crates/lib/src/types/dynamic.rs
+++ b/crates/lib/src/types/dynamic.rs
@@ -1,0 +1,265 @@
+use super::{
+    deserialize_duration, serialize_duration, Key, List, Value, ValueType,
+};
+use base64::prelude::*;
+use miette::{Error, IntoDiagnostic};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fmt;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+/// Value is a primitive value for each ValueType. Resolution for a value could be a constant,
+/// for example, an Int(1), or a resolved value from a variable.
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Dyn {
+    Int(i64),
+    Uint(u64),
+    Double(f64),
+    String(String),
+    Bool(bool),
+    Map(HashMap<Key, Value>),
+    List(Vec<Value>),
+    Bytes(Vec<u8>),
+    Null,
+    Timestamp(OffsetDateTime),
+    #[serde(
+        serialize_with = "serialize_duration",
+        deserialize_with = "deserialize_duration"
+    )]
+    Duration(time::Duration),
+}
+
+impl Dyn {
+    #[inline]
+    pub fn try_as_i64(&self) -> Result<i64, Error> {
+        match self {
+            Dyn::Int(n) => Ok(*n),
+            Dyn::Uint(n) => Ok(i64::try_from(*n).into_diagnostic()?),
+            Dyn::Double(n) => Ok(n.round() as i64),
+            Dyn::String(s) => match s.parse::<i64>() {
+                Ok(n) => Ok(n),
+                Err(e) => miette::bail!("Failed to convert to int: {e:?}"),
+            },
+            _ => miette::bail!("Failed to convert to int"),
+        }
+    }
+
+    #[inline]
+    pub fn try_as_uint(&self) -> Result<u64, Error> {
+        match self {
+            Dyn::Int(n) => Ok(u64::try_from(*n).into_diagnostic()?),
+            Dyn::Uint(n) => Ok(*n),
+            Dyn::Double(n) => Ok(n.round() as u64),
+            Dyn::String(s) => match s.parse::<u64>() {
+                Ok(n) => Ok(n),
+                Err(e) => miette::bail!("Failed to convert to uint: {e:?}"),
+            },
+            _ => miette::bail!("Failed to convert to uint"),
+        }
+    }
+
+    #[inline]
+    pub fn try_as_double(&self) -> Result<f64, Error> {
+        match self {
+            Dyn::Int(n) => {
+                if *n > f64::MAX as i64 || *n < f64::MIN as i64 {
+                    miette::bail!("Failed to convert to double: out of range")
+                } else {
+                    Ok(*n as f64)
+                }
+            }
+            Dyn::Uint(n) => {
+                if *n > f64::MAX as u64 {
+                    miette::bail!("Failed to convert to double: out of range")
+                } else {
+                    Ok(*n as f64)
+                }
+            }
+            Dyn::Double(n) => Ok(*n),
+            Dyn::String(s) => match s.parse::<f64>() {
+                Ok(n) => Ok(n),
+                Err(e) => miette::bail!("Failed to convert to double: {e:?}"),
+            },
+            _ => miette::bail!("Failed to convert to double"),
+        }
+    }
+
+    /// TODO: Figure out if base64 repr is actually right for fmt::Display
+    #[inline]
+    pub fn try_as_string(&self) -> Result<String, Error> {
+        match self {
+            Dyn::Int(n) => Ok(n.to_string()),
+            Dyn::Uint(n) => Ok(n.to_string()),
+            Dyn::Double(n) => Ok(n.to_string()),
+            Dyn::String(s) => Ok(s.clone()),
+            Dyn::Bool(b) => Ok(b.to_string()),
+            Dyn::Bytes(s) => Ok(String::from_utf8_lossy(s).to_string()),
+            Dyn::Null => Ok("null".to_string()),
+            Dyn::Timestamp(v) => Ok(v.format(&Rfc3339).unwrap()),
+            Dyn::Duration(v) => Ok(v.to_string()),
+            _ => miette::bail!("Failed to convert to string"),
+        }
+    }
+
+    #[inline]
+    pub fn try_as_bytes(&self) -> Result<Vec<u8>, Error> {
+        match self {
+            Dyn::Bytes(b) => Ok(b.clone()),
+            Dyn::String(s) => Ok(s.as_bytes().to_vec()),
+            _ => miette::bail!("Failed to convert to bytes"),
+        }
+    }
+
+    #[inline]
+    pub fn try_as_type(&self, ty: ValueType) -> Result<Value, Error> {
+        match ty {
+            ValueType::Int => Ok(Value::Int(self.try_as_i64()?)),
+            ValueType::Uint => Ok(Value::Uint(self.try_as_uint()?)),
+            ValueType::Double => Ok(Value::Double(self.try_as_double()?)),
+            ValueType::String => Ok(Value::String(self.try_as_string()?)),
+            ValueType::Bool => match self {
+                Dyn::Bool(b) => Ok(Value::Bool(*b)),
+                _ => miette::bail!("Failed to convert to bool"),
+            },
+            ValueType::Bytes => Ok(Value::Bytes(self.try_as_bytes()?)),
+            ValueType::Timestamp => match self {
+                Dyn::Timestamp(v) => Ok(Value::Timestamp(*v)),
+                _ => miette::bail!("Failed to convert to timestamp"),
+            },
+            ValueType::Duration => match self {
+                Dyn::Duration(v) => Ok(Value::Duration(*v)),
+                _ => miette::bail!("Failed to convert to duration"),
+            },
+            ValueType::List => match self {
+                Dyn::List(list) => Ok(Value::List(list.clone().try_into()?)),
+                _ => miette::bail!("Failed to convert to list"),
+            },
+            ValueType::Map => match self {
+                Dyn::Map(map) => Ok(Value::Map(map.clone().try_into()?)),
+                _ => miette::bail!("Failed to convert to map"),
+            },
+            ValueType::Null => match self {
+                Dyn::Null => Ok(Value::Null),
+                _ => miette::bail!("Failed to convert to null"),
+            },
+            // TODO: See if this is actually correct
+            ValueType::Dyn => miette::bail!("Failed to convert to dyn"),
+        }
+    }
+
+    pub fn plus(&self, other: &Value) -> Result<Value, Error> {
+        match other {
+            Value::Int(n) => Ok(Value::Int(self.try_as_i64()? + n)),
+            Value::Uint(n) => Ok(Value::Uint(self.try_as_uint()? + n)),
+            Value::Double(n) => Ok(Value::Double(self.try_as_double()? + n)),
+            Value::String(s) => {
+                Ok(Value::String(format!("{}{}", self.try_as_string()?, s)))
+            }
+            Value::Bytes(b) => {
+                let mut bytes = self.try_as_bytes()?;
+                bytes.extend_from_slice(b);
+                Ok(Value::Bytes(bytes))
+            }
+            Value::List(list) => {
+                let mut base = match self {
+                    Dyn::List(list) => match List::try_from(list.clone()) {
+                        Ok(list) => list,
+                        Err(e) => {
+                            miette::bail!("Failed to add list: {e:?}")
+                        }
+                    },
+                    _ => miette::bail!("Failed to add list"),
+                };
+
+                base.extend(list.clone());
+                Ok(Value::List(base))
+            }
+            Value::Timestamp(v) => {
+                let base = match self {
+                    Dyn::Duration(v) => *v,
+                    _ => miette::bail!("Failed to add timestamp"),
+                };
+
+                Ok(Value::Timestamp(*v + base))
+            }
+            Value::Duration(v) => match self {
+                Dyn::Duration(d) => Ok(Value::Duration(*v + *d)),
+                Dyn::Timestamp(t) => Ok(Value::Timestamp(*t + *v)),
+                _ => miette::bail!("Failed to add duration"),
+            },
+            Value::Dyn(_) => {
+                // Use self as a base
+                let s: Value = self.clone().try_into()?;
+                s.plus(other)
+            }
+
+            _ => miette::bail!(
+                "Invalid types for addition, lhs={:?}, rhs={:?}",
+                self,
+                other
+            ),
+        }
+    }
+}
+
+impl fmt::Display for Dyn {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Dyn::Int(n) => write!(f, "{n}"),
+            Dyn::Uint(n) => write!(f, "{n}"),
+            Dyn::Double(n) => write!(f, "{n}"),
+            Dyn::String(s) => write!(f, "{s}"),
+            Dyn::Bool(b) => write!(f, "{b}"),
+            Dyn::Map(map) => write!(f, "{map:?}"),
+            Dyn::List(list) => write!(f, "{list:?}"),
+            Dyn::Bytes(b) => BASE64_STANDARD.encode(b).fmt(f),
+            Dyn::Null => write!(f, "null"),
+            Dyn::Timestamp(v) => {
+                write!(f, "{}", v.format(&Rfc3339).unwrap())
+            }
+            Dyn::Duration(v) => write!(f, "{v:?}"),
+        }
+    }
+}
+
+impl From<Value> for Dyn {
+    fn from(val: Value) -> Dyn {
+        match val {
+            Value::Int(n) => Dyn::Int(n),
+            Value::Uint(n) => Dyn::Uint(n),
+            Value::Double(n) => Dyn::Double(n),
+            Value::String(s) => Dyn::String(s),
+            Value::Bool(b) => Dyn::Bool(b),
+            Value::Map(map) => Dyn::Map(map.into()),
+            Value::List(list) => Dyn::List(list.into()),
+            Value::Bytes(b) => Dyn::Bytes(b),
+            Value::Null => Dyn::Null,
+            Value::Timestamp(v) => Dyn::Timestamp(v),
+            Value::Duration(v) => Dyn::Duration(v),
+            Value::Dyn(d) => d,
+        }
+    }
+}
+
+impl TryFrom<Dyn> for Value {
+    type Error = Error;
+
+    fn try_from(d: Dyn) -> Result<Value, Error> {
+        let val = match d {
+            Dyn::Int(n) => Value::Int(n),
+            Dyn::Uint(n) => Value::Uint(n),
+            Dyn::Double(n) => Value::Double(n),
+            Dyn::String(s) => Value::String(s),
+            Dyn::Bool(b) => Value::Bool(b),
+            Dyn::Map(map) => Value::Map(map.try_into()?),
+            Dyn::List(list) => Value::List(list.try_into()?),
+            Dyn::Bytes(b) => Value::Bytes(b),
+            Dyn::Null => Value::Null,
+            Dyn::Timestamp(v) => Value::Timestamp(v),
+            Dyn::Duration(v) => Value::Duration(v),
+        };
+        Ok(val)
+    }
+}

--- a/crates/lib/src/types/dynamic.rs
+++ b/crates/lib/src/types/dynamic.rs
@@ -49,6 +49,7 @@ impl Dyn {
         }
     }
 
+    /// Tries to convert &self to i64
     #[inline]
     pub fn try_to_i64(&self) -> Result<i64, Error> {
         self.clone().try_into_i64()
@@ -67,6 +68,12 @@ impl Dyn {
             },
             _ => miette::bail!("Failed to convert to uint"),
         }
+    }
+
+    /// Tries to convert &self to u64
+    #[inline]
+    pub fn try_to_u64(&self) -> Result<u64, Error> {
+        self.clone().try_into_u64()
     }
 
     /// Tries to convert self into f64
@@ -96,6 +103,7 @@ impl Dyn {
         }
     }
 
+    /// Tries to convert &self into f64
     #[inline]
     pub fn try_to_f64(&self) -> Result<f64, Error> {
         self.clone().try_into_f64()
@@ -118,6 +126,7 @@ impl Dyn {
         }
     }
 
+    /// Tries to convert &self to string
     #[inline]
     pub fn try_to_string(&self) -> Result<String, Error> {
         self.clone().try_into_string()
@@ -133,6 +142,7 @@ impl Dyn {
         }
     }
 
+    /// Tries to convert &self to bytes
     #[inline]
     pub fn try_to_bytes(&self) -> Result<Vec<u8>, Error> {
         self.clone().try_into_bytes()
@@ -167,6 +177,7 @@ impl Dyn {
         }
     }
 
+    /// Tries to convert &self to list
     #[inline]
     pub fn try_to_list_of(&self, ty: ValueType) -> Result<List, Error> {
         self.clone().try_into_list_of(ty)
@@ -217,6 +228,7 @@ impl Dyn {
         }
     }
 
+    /// Tries to convert &self to map
     #[inline]
     pub fn try_to_map_of(&self, ty: ValueType) -> Result<Map, Error> {
         self.clone().try_into_map_of(ty)
@@ -253,6 +265,7 @@ impl Dyn {
         }
     }
 
+    /// Tries to convert &self to value of type
     #[inline]
     pub fn try_to_type(&self, ty: ValueType) -> Result<Value, Error> {
         self.clone().try_into_type(ty)

--- a/crates/lib/src/types/dynamic.rs
+++ b/crates/lib/src/types/dynamic.rs
@@ -48,7 +48,7 @@ impl Dyn {
     }
 
     #[inline]
-    pub fn try_as_uint(&self) -> Result<u64, Error> {
+    pub fn try_as_u64(&self) -> Result<u64, Error> {
         match self {
             Dyn::Int(n) => Ok(u64::try_from(*n).into_diagnostic()?),
             Dyn::Uint(n) => Ok(*n),
@@ -62,7 +62,7 @@ impl Dyn {
     }
 
     #[inline]
-    pub fn try_as_double(&self) -> Result<f64, Error> {
+    pub fn try_as_f64(&self) -> Result<f64, Error> {
         match self {
             Dyn::Int(n) => {
                 if *n > f64::MAX as i64 || *n < f64::MIN as i64 {
@@ -87,7 +87,6 @@ impl Dyn {
         }
     }
 
-    /// TODO: Figure out if base64 repr is actually right for fmt::Display
     #[inline]
     pub fn try_as_string(&self) -> Result<String, Error> {
         match self {
@@ -174,7 +173,7 @@ impl Dyn {
     pub fn try_as_key_type(&self, ty: KeyType) -> Result<Key, Error> {
         match ty {
             KeyType::Int => Ok(Key::Int(self.try_as_i64()?)),
-            KeyType::Uint => Ok(Key::Uint(self.try_as_uint()?)),
+            KeyType::Uint => Ok(Key::Uint(self.try_as_u64()?)),
             KeyType::String => Ok(Key::String(self.try_as_string()?)),
             KeyType::Bool => match self {
                 Dyn::Bool(b) => Ok(Key::Bool(*b)),
@@ -187,8 +186,8 @@ impl Dyn {
     pub fn try_as_type(&self, ty: ValueType) -> Result<Value, Error> {
         match ty {
             ValueType::Int => Ok(Value::Int(self.try_as_i64()?)),
-            ValueType::Uint => Ok(Value::Uint(self.try_as_uint()?)),
-            ValueType::Double => Ok(Value::Double(self.try_as_double()?)),
+            ValueType::Uint => Ok(Value::Uint(self.try_as_u64()?)),
+            ValueType::Double => Ok(Value::Double(self.try_as_f64()?)),
             ValueType::String => Ok(Value::String(self.try_as_string()?)),
             ValueType::Bool => match self {
                 Dyn::Bool(b) => Ok(Value::Bool(*b)),
@@ -209,7 +208,6 @@ impl Dyn {
                 Dyn::Null => Ok(Value::Null),
                 _ => miette::bail!("Failed to convert to null"),
             },
-            // TODO: See if this is actually correct
             ValueType::Dyn => miette::bail!("Failed to convert to dyn"),
         }
     }

--- a/crates/lib/src/types/list.rs
+++ b/crates/lib/src/types/list.rs
@@ -480,19 +480,27 @@ impl FromIterator<Value> for List {
     }
 }
 
-impl<T> From<Vec<T>> for List
+impl<T> TryFrom<Vec<T>> for List
 where
     T: Into<Value>,
 {
-    fn from(values: Vec<T>) -> Self {
+    type Error = Error;
+    fn try_from(values: Vec<T>) -> Result<Self, Error> {
         if values.is_empty() {
-            Self::new()
+            Ok(Self::new())
         } else {
             let mut list = List::with_capacity(values.len());
-            list.inner = values.into_iter().map(Into::into).collect();
-            list.elem_type = list.inner.first().map(Value::type_of);
-            list
+            for value in values {
+                list.push(value.into())?;
+            }
+            Ok(list)
         }
+    }
+}
+
+impl From<List> for Vec<Value> {
+    fn from(list: List) -> Self {
+        list.inner
     }
 }
 
@@ -526,7 +534,7 @@ impl<'de> Deserialize<'de> for List {
         D: Deserializer<'de>,
     {
         let inner: Vec<Value> = Vec::deserialize(deserializer)?;
-        Ok(List::from(inner))
+        Ok(List::try_from(inner).map_err(serde::de::Error::custom)?)
     }
 }
 

--- a/crates/lib/src/types/list.rs
+++ b/crates/lib/src/types/list.rs
@@ -534,7 +534,7 @@ impl<'de> Deserialize<'de> for List {
         D: Deserializer<'de>,
     {
         let inner: Vec<Value> = Vec::deserialize(deserializer)?;
-        Ok(List::try_from(inner).map_err(serde::de::Error::custom)?)
+        List::try_from(inner).map_err(serde::de::Error::custom)
     }
 }
 

--- a/crates/lib/src/types/map.rs
+++ b/crates/lib/src/types/map.rs
@@ -60,7 +60,7 @@ impl Map {
 
     #[inline]
     pub fn key_type(&self) -> Option<KeyType> {
-        self.key_type.clone()
+        self.key_type
     }
 
     #[inline]
@@ -456,7 +456,7 @@ impl<'de> Deserialize<'de> for Map {
         D: Deserializer<'de>,
     {
         let inner = HashMap::<Key, Value>::deserialize(deserializer)?;
-        Ok(Map::try_from(inner).map_err(serde::de::Error::custom)?)
+        Map::try_from(inner).map_err(serde::de::Error::custom)
     }
 }
 

--- a/crates/lib/src/types/map.rs
+++ b/crates/lib/src/types/map.rs
@@ -71,6 +71,17 @@ impl Map {
         }
     }
 
+    #[inline]
+    pub fn with_key_type_and_capacity(
+        key_type: KeyType,
+        capacity: usize,
+    ) -> Self {
+        Self {
+            key_type: Some(key_type),
+            inner: HashMap::with_capacity(capacity),
+        }
+    }
+
     /// Wrapper for [capacity](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.capacity)
     #[inline]
     pub fn capacity(&self) -> usize {

--- a/crates/lib/src/types/map.rs
+++ b/crates/lib/src/types/map.rs
@@ -461,7 +461,7 @@ impl<'de> Deserialize<'de> for Map {
 }
 
 /// KeyType represents the type of the key.
-#[derive(Debug, PartialEq, Clone, Hash, Eq, PartialOrd, Ord)]
+#[derive(Copy, Debug, PartialEq, Clone, Hash, Eq, PartialOrd, Ord)]
 pub enum KeyType {
     Int,
     Uint,

--- a/crates/lib/src/types/mod.rs
+++ b/crates/lib/src/types/mod.rs
@@ -1,5 +1,6 @@
 mod de;
 pub mod duration;
+pub mod dynamic;
 pub mod list;
 pub mod map;
 mod ser;

--- a/crates/lib/src/types/ser.rs
+++ b/crates/lib/src/types/ser.rs
@@ -32,7 +32,12 @@ impl serde::ser::SerializeSeq for SerializeSeq {
     }
 
     fn end(self) -> Result<Value, SerializeError> {
-        Ok(Value::List(List::from(self.inner)))
+        Ok(Value::List(match List::try_from(self.inner) {
+            Ok(list) => list,
+            Err(err) => {
+                return Err(SerializeError::InvalidKey(err.to_string()))
+            }
+        }))
     }
 }
 

--- a/crates/lib/src/types/value.rs
+++ b/crates/lib/src/types/value.rs
@@ -589,16 +589,16 @@ impl Value {
             }
             (Value::Dyn(d1), Value::Dyn(d2)) => {
                 let v1: Value = d1.clone().try_into()?;
-                let v2 = d2.try_as_type(v1.type_of())?;
+                let v2 = d2.try_to_type(v1.type_of())?;
                 v1.plus(&v2)
             }
             (Value::Dyn(d), other) => {
-                let v = d.try_as_type(other.type_of())?;
+                let v = d.try_to_type(other.type_of())?;
                 v.plus(other)
             }
             (base, Value::Dyn(d)) => {
                 // plus is not associative, so we need to try both ways
-                let other = d.try_as_type(base.type_of())?;
+                let other = d.try_to_type(base.type_of())?;
                 base.plus(&other)
             }
             _ => miette::bail!(
@@ -626,16 +626,16 @@ impl Value {
             }
             (Value::Dyn(d1), Value::Dyn(d2)) => {
                 let v1: Value = d1.clone().try_into()?;
-                let v2 = d2.try_as_type(v1.type_of())?;
+                let v2 = d2.try_to_type(v1.type_of())?;
                 v1.minus(&v2)
             }
             (Value::Dyn(d), other) => {
-                let v = d.try_as_type(other.type_of())?;
+                let v = d.try_to_type(other.type_of())?;
                 v.minus(other)
             }
             (base, Value::Dyn(d)) => {
                 // minus is not associative, so we need to try both ways
-                let other = d.try_as_type(base.type_of())?;
+                let other = d.try_to_type(base.type_of())?;
                 base.minus(&other)
             }
             _ => miette::bail!(
@@ -654,16 +654,16 @@ impl Value {
         match (self, other) {
             (Value::Dyn(d1), Value::Dyn(d2)) => {
                 let v1: Value = d1.clone().try_into()?;
-                let v2 = d2.try_as_type(v1.type_of())?;
+                let v2 = d2.try_to_type(v1.type_of())?;
                 v1.equal(&v2)
             }
             (Value::Dyn(d), other) => {
-                let v = d.try_as_type(other.type_of())?;
+                let v = d.try_to_type(other.type_of())?;
                 v.equal(other)
             }
             (base, Value::Dyn(d)) => {
                 // equal is not associative, so we need to try both ways
-                let other = d.try_as_type(base.type_of())?;
+                let other = d.try_to_type(base.type_of())?;
                 base.equal(&other)
             }
             (lhs, rhs) => {
@@ -703,16 +703,16 @@ impl Value {
             (Value::Duration(d1), Value::Duration(d2)) => Value::Bool(d1 > d2),
             (Value::Dyn(d1), Value::Dyn(d2)) => {
                 let v1: Value = d1.clone().try_into()?;
-                let v2 = d2.try_as_type(v1.type_of())?;
+                let v2 = d2.try_to_type(v1.type_of())?;
                 v1.greater(&v2)?
             }
             (Value::Dyn(d), other) => {
-                let v = d.try_as_type(other.type_of())?;
+                let v = d.try_to_type(other.type_of())?;
                 v.greater(other)?
             }
             (base, Value::Dyn(d)) => {
                 // greater is not associative, so we need to try both ways
-                let other = d.try_as_type(base.type_of())?;
+                let other = d.try_to_type(base.type_of())?;
                 base.greater(&other)?
             }
             (left, right) => {
@@ -737,15 +737,15 @@ impl Value {
             (Value::Duration(d1), Value::Duration(d2)) => Value::Bool(d1 >= d2),
             (Value::Dyn(d1), Value::Dyn(d2)) => {
                 let v1: Value = d1.clone().try_into()?;
-                let v2 = d2.try_as_type(v1.type_of())?;
+                let v2 = d2.try_to_type(v1.type_of())?;
                 v1.greater_equal(&v2)?
             }
             (Value::Dyn(d), other) => {
-                let v = d.try_as_type(other.type_of())?;
+                let v = d.try_to_type(other.type_of())?;
                 v.greater_equal(other)?
             }
             (base, Value::Dyn(d)) => {
-                let other = d.try_as_type(base.type_of())?;
+                let other = d.try_to_type(base.type_of())?;
                 base.greater_equal(&other)?
             }
             _ => miette::bail!("Failed to compare {self:?} >= {other:?}"),
@@ -768,15 +768,15 @@ impl Value {
             (Value::Duration(d1), Value::Duration(d2)) => Value::Bool(d1 < d2),
             (Value::Dyn(d1), Value::Dyn(d2)) => {
                 let v1: Value = d1.clone().try_into()?;
-                let v2 = d2.try_as_type(v1.type_of())?;
+                let v2 = d2.try_to_type(v1.type_of())?;
                 v1.less(&v2)?
             }
             (Value::Dyn(d), other) => {
-                let v = d.try_as_type(other.type_of())?;
+                let v = d.try_to_type(other.type_of())?;
                 v.less(other)?
             }
             (base, Value::Dyn(d)) => {
-                let other = d.try_as_type(base.type_of())?;
+                let other = d.try_to_type(base.type_of())?;
                 base.less(&other)?
             }
             _ => miette::bail!("Failed to compare {self:?} < {other:?}"),
@@ -799,15 +799,15 @@ impl Value {
             (Value::Duration(d1), Value::Duration(d2)) => Value::Bool(d1 <= d2),
             (Value::Dyn(d1), Value::Dyn(d2)) => {
                 let v1: Value = d1.clone().try_into()?;
-                let v2 = d2.try_as_type(v1.type_of())?;
+                let v2 = d2.try_to_type(v1.type_of())?;
                 v1.less_equal(&v2)?
             }
             (Value::Dyn(d), other) => {
-                let v = d.try_as_type(other.type_of())?;
+                let v = d.try_to_type(other.type_of())?;
                 v.less_equal(other)?
             }
             (base, Value::Dyn(d)) => {
-                let other = d.try_as_type(base.type_of())?;
+                let other = d.try_to_type(base.type_of())?;
                 base.less_equal(&other)?
             }
             _ => miette::bail!("Failed to compare {self:?} <= {other:?}"),
@@ -825,15 +825,15 @@ impl Value {
             }
             (Value::Dyn(d1), Value::Dyn(d2)) => {
                 let v1: Value = d1.clone().try_into()?;
-                let v2 = d2.try_as_type(v1.type_of())?;
+                let v2 = d2.try_to_type(v1.type_of())?;
                 v1.multiply(&v2)?
             }
             (Value::Dyn(d), other) => {
-                let v = d.try_as_type(other.type_of())?;
+                let v = d.try_to_type(other.type_of())?;
                 v.multiply(other)?
             }
             (base, Value::Dyn(d)) => {
-                let other = d.try_as_type(base.type_of())?;
+                let other = d.try_to_type(base.type_of())?;
                 base.multiply(&other)?
             }
             _ => miette::bail!("Failed to multiply {self:?} * {other:?}"),
@@ -851,15 +851,15 @@ impl Value {
             }
             (Value::Dyn(d1), Value::Dyn(d2)) => {
                 let v1: Value = d1.clone().try_into()?;
-                let v2 = d2.try_as_type(v1.type_of())?;
+                let v2 = d2.try_to_type(v1.type_of())?;
                 v1.devide(&v2)?
             }
             (Value::Dyn(d), other) => {
-                let v = d.try_as_type(other.type_of())?;
+                let v = d.try_to_type(other.type_of())?;
                 v.devide(other)?
             }
             (base, Value::Dyn(d)) => {
-                let other = d.try_as_type(base.type_of())?;
+                let other = d.try_to_type(base.type_of())?;
                 base.devide(&other)?
             }
             _ => miette::bail!("Failed to devide {self:?} / {other:?}"),
@@ -874,15 +874,15 @@ impl Value {
             (Value::Uint(lhs), Value::Uint(rhs)) => Value::Uint(lhs % rhs),
             (Value::Dyn(d1), Value::Dyn(d2)) => {
                 let v1: Value = d1.clone().try_into()?;
-                let v2 = d2.try_as_type(v1.type_of())?;
+                let v2 = d2.try_to_type(v1.type_of())?;
                 v1.reminder(&v2)?
             }
             (Value::Dyn(d), other) => {
-                let v = d.try_as_type(other.type_of())?;
+                let v = d.try_to_type(other.type_of())?;
                 v.reminder(other)?
             }
             (base, Value::Dyn(d)) => {
-                let other = d.try_as_type(base.type_of())?;
+                let other = d.try_to_type(base.type_of())?;
                 base.reminder(&other)?
             }
             _ => miette::bail!("Failed to get reminder {self:?} % {other:?}"),
@@ -900,7 +900,7 @@ impl Value {
                 }
             }
             (Value::List(list), Value::Dyn(d)) => {
-                let index = d.try_as_i64()?;
+                let index = d.try_to_i64()?;
                 match list.get(index as usize) {
                     Some(v) => Ok(v.clone()),
                     None => miette::bail!("Index out of range: {:?}", index),
@@ -922,7 +922,7 @@ impl Value {
                 Dyn::List(list) => {
                     let index = match index {
                         Value::Int(n) => *n,
-                        Value::Dyn(d) => d.try_as_i64()?,
+                        Value::Dyn(d) => d.try_to_i64()?,
                         _ => miette::bail!("Cannot index into {:?}", index),
                     };
                     match list.get(index as usize) {


### PR DESCRIPTION
Previously, `dyn` was used as a function call. Since the spec says that dyn is just a hint for the type checker, an additional variant is added to the `Value`. The function call is removed from the default functions, and lexer now emits the `dyn` token, leaving it out to the parser to check the arguments.

Also, during `dyn` fix, additional issue was discovered for the function call so that one is also fixed in this PR

Map doesn't implement the `From`, but `TryFrom`, since the type check is being done on keys. Same goes for the `List` type.