### PR TITLE
Expose default functions map

### DIFF
--- a/crates/lib/src/environment.rs
+++ b/crates/lib/src/environment.rs
@@ -99,7 +99,8 @@ impl Environment<'_> {
     }
 }
 
-fn default_functions() -> &'static HashMap<String, Function> {
+/// standard functions exposed by each environment, created during root environment creation
+pub fn default_functions() -> &'static HashMap<String, Function> {
     static FUNCTIONS: OnceLock<HashMap<String, Function>> = OnceLock::new();
     FUNCTIONS.get_or_init(|| {
         let mut m = HashMap::new();


### PR DESCRIPTION
Exposing default functions helps during evaluation of the expression. The user can check while validating using AST (TokenTree) if the function name is either a name provided by user, or one of the default functions exposed by the standard evaluation environment.